### PR TITLE
Terraform log_format not escaped

### DIFF
--- a/Terraform/userdata.sh
+++ b/Terraform/userdata.sh
@@ -126,9 +126,9 @@ cat <<EOF >/etc/nginx/nginx.conf
 
     include    /etc/nginx/conf.d/*.conf;
     default_type  application/octet-stream;
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-    '$status $body_bytes_sent "$http_referer" '
-    '"$http_user_agent" "$http_x_forwarded_for"';
+    log_format  main  '\$remote_addr - \$remote_user [\$time_local] "\$request" '
+    '\$status \$body_bytes_sent "\$http_referer" '
+    '"\$http_user_agent" "\$http_x_forwarded_for"';
     access_log  /var/log/nginx/access.log  main;
     sendfile        on;
     #tcp_nopush     on;


### PR DESCRIPTION
NGINX access logs looked like ` -  [] ""   "" "" ""` before escaping this since nginx needs the literal "$values" but bash was interpreting them.