### PR TITLE
Arm template fix vms

### DIFF
--- a/AzureResourceManager/MP_submission_7/createUiDefinition.json
+++ b/AzureResourceManager/MP_submission_7/createUiDefinition.json
@@ -82,7 +82,6 @@
             ],
             "constraints": {
               "allowedSizes": [
-                "Standard_A2_v2",
                 "Standard_A4_v2",
                 "Standard_A4",
                 "Standard_D2s_v3",

--- a/AzureResourceManager/azuredeploy.json
+++ b/AzureResourceManager/azuredeploy.json
@@ -205,7 +205,7 @@
       "metadata": {
         "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
       },
-      "defaultValue": "https://raw.githubusercontent.com/jfrog/JFrog-Cloud-Installers/refactoring-rt6-rt7/AzureResourceManager/"
+      "defaultValue": "https://raw.githubusercontent.com/jfrog/JFrog-Cloud-Installers/master/AzureResourceManager/"
     },
     "_artifactsLocationSasToken": {
       "type": "securestring",

--- a/JFrogContainerRegistry/AzureResourceManager/MP_submission_7/createUiDefinition.json
+++ b/JFrogContainerRegistry/AzureResourceManager/MP_submission_7/createUiDefinition.json
@@ -78,11 +78,10 @@
             "label": "Virtual machine size",
             "toolTip": "The size of the virtual machine for JFrog Container Registry",
             "recommendedSizes": [
-              "Standard_A2_v2"
+              "Standard_D2s_v3"
             ],
             "constraints": {
               "allowedSizes": [
-                "Standard_A2_v2",
                 "Standard_A4_v2",
                 "Standard_A4",
                 "Standard_D2s_v3",

--- a/JFrogContainerRegistry/AzureResourceManager/MP_submission_7/mainTemplate.json
+++ b/JFrogContainerRegistry/AzureResourceManager/MP_submission_7/mainTemplate.json
@@ -4,7 +4,7 @@
   "parameters": {
     "vmSku": {
       "type": "string",
-      "defaultValue": "Standard_A2_v2",
+      "defaultValue": "Standard_D2s_v3",
       "metadata": {
         "description": "Size of VMs in the VM Scale Set."
       }

--- a/JFrogContainerRegistry/AzureResourceManager/azuredeploy.json
+++ b/JFrogContainerRegistry/AzureResourceManager/azuredeploy.json
@@ -4,7 +4,7 @@
   "parameters": {
     "vmSku": {
       "type": "string",
-      "defaultValue": "Standard_A2_v2",
+      "defaultValue": "Standard_D2s_v3",
       "metadata": {
         "description": "Size of VMs in the VM Scale Set."
       }

--- a/JFrogContainerRegistry/AzureResourceManager/azuredeploy.json
+++ b/JFrogContainerRegistry/AzureResourceManager/azuredeploy.json
@@ -144,7 +144,7 @@
       "metadata": {
         "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
       },
-      "defaultValue": "https://raw.githubusercontent.com/JFrogDev/JFrog-Cloud-Installers/refactoring-rt7/JFrogContainerRegistry/AzureResourceManager/"
+      "defaultValue": "https://raw.githubusercontent.com/JFrogDev/JFrog-Cloud-Installers/master/JFrogContainerRegistry/AzureResourceManager/"
     },
     "_artifactsLocationSasToken": {
       "type": "securestring",


### PR DESCRIPTION
Standard_A2_v2 is removed from both HA and JCR templates. 