### PR TITLE
ARM template bug fixes and improvements

### DIFF
--- a/AzureResourceManager/Artifactory/MP_submission/nested/Postgresql_deploy.json
+++ b/AzureResourceManager/Artifactory/MP_submission/nested/Postgresql_deploy.json
@@ -37,7 +37,7 @@
     },
     "skuSizeMB": {
       "type": "int",
-      "defaultValue": 5120
+      "defaultValue": 102400
     },
     "skuTier": {
       "type": "string",

--- a/AzureResourceManager/Artifactory/MP_submission/scripts/install_artifactory7.sh
+++ b/AzureResourceManager/Artifactory/MP_submission/scripts/install_artifactory7.sh
@@ -68,9 +68,9 @@ cat <<EOF >/etc/nginx/nginx.conf
 
     include    /etc/nginx/conf.d/*.conf;
     default_type  application/octet-stream;
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-    '$status $body_bytes_sent "$http_referer" '
-    '"$http_user_agent" "$http_x_forwarded_for"';
+    log_format  main  '\$remote_addr - \$remote_user [\$time_local] "\$request" '
+    '\$status \$body_bytes_sent "\$http_referer" '
+    '"\$http_user_agent" "\$http_x_forwarded_for"';
     access_log  /var/log/nginx/access.log  main;
     sendfile        on;
     #tcp_nopush     on;

--- a/AzureResourceManager/Artifactory/nested/Postgresql_deploy.json
+++ b/AzureResourceManager/Artifactory/nested/Postgresql_deploy.json
@@ -37,7 +37,7 @@
     },
     "skuSizeMB": {
       "type": "int",
-      "defaultValue": 5120
+      "defaultValue": 102400
     },
     "skuTier": {
       "type": "string",

--- a/AzureResourceManager/Artifactory/scripts/install_artifactory7.sh
+++ b/AzureResourceManager/Artifactory/scripts/install_artifactory7.sh
@@ -68,9 +68,9 @@ cat <<EOF >/etc/nginx/nginx.conf
 
     include    /etc/nginx/conf.d/*.conf;
     default_type  application/octet-stream;
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-    '$status $body_bytes_sent "$http_referer" '
-    '"$http_user_agent" "$http_x_forwarded_for"';
+    log_format  main  '\$remote_addr - \$remote_user [\$time_local] "\$request" '
+    '\$status \$body_bytes_sent "\$http_referer" '
+    '"\$http_user_agent" "\$http_x_forwarded_for"';
     access_log  /var/log/nginx/access.log  main;
     sendfile        on;
     #tcp_nopush     on;

--- a/AzureResourceManager/Artifactory/scripts/install_artifactory7.sh
+++ b/AzureResourceManager/Artifactory/scripts/install_artifactory7.sh
@@ -256,6 +256,17 @@ cat /tmp/temp.key | sed 's/KEY----- /&\n/' | sed 's/ -----END/\n-----END/' | awk
     rm /tmp/temp.key
 fi
 
+cat <<EOF >/var/opt/jfrog/artifactory/etc/info/installer-info.json
+{
+  "productId": "ARM_artifactory-pro-template/1.0.0",
+  "features": [
+    {
+      "featureId": "Partner/ACC-007221"
+    }
+  ]
+}
+EOF
+
 chown artifactory:artifactory -R /var/opt/jfrog/artifactory/*  && chown artifactory:artifactory -R /var/opt/jfrog/artifactory/etc/security && chown artifactory:artifactory -R /var/opt/jfrog/artifactory/etc/*
 
 # start Artifactory

--- a/AzureResourceManager/Artifactory/vm_install/install_pro7_to_vm.sh
+++ b/AzureResourceManager/Artifactory/vm_install/install_pro7_to_vm.sh
@@ -25,7 +25,7 @@ apt-get -y install jfrog-artifactory-pro=${ARTIFACTORY_VERSION} >> /tmp/install-
 mkdir -p /var/opt/jfrog/artifactory/etc/info
 cat <<EOF >/var/opt/jfrog/artifactory/etc/info/installer-info.json
 {
-  "productId": "ARM_artifactory-pro/1.0.0",
+  "productId": "ARM_artifactory-pro-vm/1.0.0",
   "features": [
     {
       "featureId": "Partner/ACC-007221"

--- a/AzureResourceManager/JCR/MP_submission_7/scripts/install_artifactory7.sh
+++ b/AzureResourceManager/JCR/MP_submission_7/scripts/install_artifactory7.sh
@@ -57,9 +57,9 @@ cat <<EOF >/etc/nginx/nginx.conf
 
     include    /etc/nginx/conf.d/*.conf;
     default_type  application/octet-stream;
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-    '$status $body_bytes_sent "$http_referer" '
-    '"$http_user_agent" "$http_x_forwarded_for"';
+    log_format  main  '\$remote_addr - \$remote_user [\$time_local] "\$request" '
+    '\$status \$body_bytes_sent "\$http_referer" '
+    '"\$http_user_agent" "\$http_x_forwarded_for"';
     access_log  /var/log/nginx/access.log  main;
     sendfile        on;
     #tcp_nopush     on;

--- a/AzureResourceManager/JCR/scripts/install_artifactory7.sh
+++ b/AzureResourceManager/JCR/scripts/install_artifactory7.sh
@@ -57,9 +57,9 @@ cat <<EOF >/etc/nginx/nginx.conf
 
     include    /etc/nginx/conf.d/*.conf;
     default_type  application/octet-stream;
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-    '$status $body_bytes_sent "$http_referer" '
-    '"$http_user_agent" "$http_x_forwarded_for"';
+    log_format  main  '\$remote_addr - \$remote_user [\$time_local] "\$request" '
+    '\$status \$body_bytes_sent "\$http_referer" '
+    '"\$http_user_agent" "\$http_x_forwarded_for"';
     access_log  /var/log/nginx/access.log  main;
     sendfile        on;
     #tcp_nopush     on;

--- a/AzureResourceManager/Postgresql/azurePostgresDBDeploy.json
+++ b/AzureResourceManager/Postgresql/azurePostgresDBDeploy.json
@@ -38,7 +38,7 @@
     },
     "skuSizeMB": {
       "type": "int",
-      "defaultValue": 5120
+      "defaultValue": 204800
     },
     "skuTier": {
       "type": "string",


### PR DESCRIPTION
- Fixed bug in the Nginx config (not escaped $ characters)
- Postgresql storage increased for Xray and Artifactory, as well as in standalone Postgresql template. Default 5 Gb is not enough for both.  
- Different callhome data is used by the plain VM image and if this image is used in the ARM template (PTRENG-1226)