### PR TITLE
[all/artifactory] binarystore.xml must be located in path $ARTIFACTORY_HOME/etc/artifactory/

### DIFF
--- a/Ansible/ansible_collections/jfrog/installers/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/installers/roles/artifactory/tasks/install.yml
@@ -153,14 +153,14 @@
 - name: use specified binary store
   copy:
     src: "{{ binary_store_file }}"
-    dest: "{{ artifactory_home }}/var/etc/binarystore.xml"
+    dest: "{{ artifactory_home }}/var/etc/artifactory/binarystore.xml"
   become: yes
   when: binary_store_file is defined
 
 - name: use default binary store
   template:
     src: binarystore.xml.j2
-    dest: "{{ artifactory_home }}/var/etc/binarystore.xml"
+    dest: "{{ artifactory_home }}/var/etc/artifactory/binarystore.xml"
   become: yes
   when: binary_store_file is not defined
 

--- a/AzureResourceManager/JCR/MP_submission_6/scripts/install_artifactory.sh
+++ b/AzureResourceManager/JCR/MP_submission_6/scripts/install_artifactory.sh
@@ -138,7 +138,7 @@ cat <<EOF >/var/opt/jfrog/artifactory/etc/security/master.key
 ${MASTER_KEY}
 EOF
 
-cat <<EOF >/var/opt/jfrog/artifactory/etc/binarystore.xml
+cat <<EOF >/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml
 <config version="2">
     <chain>
        <provider id="cache-fs-eventual-azure-blob-storage" type="cache-fs">

--- a/AzureResourceManager/JCR/scripts/install_artifactory.sh
+++ b/AzureResourceManager/JCR/scripts/install_artifactory.sh
@@ -138,7 +138,7 @@ cat <<EOF >/var/opt/jfrog/artifactory/etc/security/master.key
 ${MASTER_KEY}
 EOF
 
-cat <<EOF >/var/opt/jfrog/artifactory/etc/binarystore.xml
+cat <<EOF >/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml
 <config version="2">
     <chain>
        <provider id="cache-fs-eventual-azure-blob-storage" type="cache-fs">

--- a/CloudFormation/artifactory-enterprise.json
+++ b/CloudFormation/artifactory-enterprise.json
@@ -674,7 +674,7 @@
                 "group"  : "artifactory"
               },
 
-              "/var/opt/jfrog/artifactory/etc/binarystore.xml" : {
+              "/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml" : {
                 "content" : { "Fn::Join" : ["", [
                   "<config version=\"2\">\n",
                   "<chain> <!--template=\"cluster-s3\"-->\n",
@@ -1102,7 +1102,7 @@
                 "group"  : "artifactory"
               },
 
-              "/var/opt/jfrog/artifactory/etc/binarystore.xml" : {
+              "/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml" : {
                 "content" : { "Fn::Join" : ["", [
                   "<config version=\"2\">\n",
                   "<chain> <!--template=\"cluster-s3\"-->\n",

--- a/Terraform/userdata.sh
+++ b/Terraform/userdata.sh
@@ -14,7 +14,7 @@ yum install -y nginx>> /tmp/yum-nginx.log 2>&1
 curl -L -o  /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.38.jar https://bintray.com/artifact/download/bintray/jcenter/mysql/mysql-connector-java/5.1.38/mysql-connector-java-5.1.38.jar
 openssl req -nodes -x509 -newkey rsa:4096 -keyout /etc/pki/tls/private/example.key -out /etc/pki/tls/certs/example.pem -days 356 -subj "/C=US/ST=California/L=SantaClara/O=IT/CN=*.localhost"
 
-cat <<EOF >/var/opt/jfrog/artifactory/etc/binarystore.xml
+cat <<EOF >/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml
 <config version="2">
     <chain> <!--template="cluster-s3"-->
         <provider id="cache-fs-eventual-s3" type="cache-fs">


### PR DESCRIPTION

**What this PR does / why we need it**:

According to the documentation (+ tests performed with HA setup), the binarystore.xml file must be located in path $ARTIFACTORY_HOME/etc/artifactory/.
Otherwise Artifactory generates the default one during first startup.

> https://www.jfrog.com/confluence/display/JFROG/Configuring+the+Filestore

**Which issue this PR fixes**:

N/A

**Special notes for your reviewer**:

Tested for Ansible, but not for Azure and Terraform.
