### PR TITLE
Update cla assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,5 +1,6 @@
 name: "CLA Assistant"
 on:
+  # issue_comment triggers this action on each comment on issues and pull requests
   issue_comment:
     types: [created]
   pull_request_target:
@@ -9,10 +10,16 @@ jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: sign-or-recheck
+        with:
+          text: ${{ github.event.comment.body }}
+          regex: '\s*(I have read the CLA Document and I hereby sign the CLA)|(recheckcla)\s*'
+      
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: ${{ steps.sign-or-recheck.outputs.match != '' || github.event_name == 'pull_request_target' }}
         # Alpha Release
-        uses: cla-assistant/github-action@v2.0.1-alpha
+        uses: cla-assistant/github-action@v2.1.1-beta
         env:
           # Generated and maintained by github
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -20,7 +27,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_SIGN_TOKEN }}
         with:
           path-to-signatures: 'signed_clas.json'
-          path-to-cla-document: 'https://jfrog.com/cla/'
+          path-to-document: 'https://jfrog.com/cla/'
           remote-organization-name: 'jfrog'
           remote-repository-name: 'jfrog-signed-clas'
           # branch should not be protected


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the CLA assistant to accept whitespace between "I have read the CLA Document and I hereby sign the CLA" comment. Same as https://github.com/jfrog/jfrog-cli/blob/master/.github/workflows/cla.yml

