### PR TITLE
[ansible/postgres] Do not require mission control when provisioning postgres role

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/postgres/tasks/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/postgres/tasks/main.yml
@@ -84,11 +84,13 @@
   become_user: postgres
   command: psql -d {{ mc_db_name }} -t -c "\dn"
   register: mc_schemas_loaded
+  when: mc_db_name is defined
 
 - name: Create schemas for mission-control
   become: yes
   become_user: postgres
   command: psql -d {{ mc_db_name }} -c 'CREATE SCHEMA {{ item }} authorization {{ mc_db_user }}'
+  when: mc_db_name is defined
   loop: "{{  mc_schemas|default([]) }}"
   when: "mc_schemas_loaded.stdout is defined and '{{ item }}' not in mc_schemas_loaded.stdout"
 
@@ -101,6 +103,7 @@
     type: schema
     roles: "{{ mc_db_user }}"
     objs: "{{ item }}"
+  when: mc_db_name is defined
   loop: "{{ mc_schemas|default([]) }}"
 
 - name: Grant privs on db


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

If mc_db_name is not given it is assumed that no tables or users should be configured for mission control.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Unable to provision artifactory using Ansible, since I do not use mission control and postgres role required it.

**Special notes for your reviewer**:

Since this contribution is done using work e-mail I cannot sign CLA due to patent clause. However, the change is so trivial so I'm perfectly fine if you just deny this PR and do an identical change yourself. I just want the fix, doesn't matter who the author is.