### PR TITLE
[ansible/all] customize timeout when download tar

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
+++ b/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Platform Ansible Collection Changelog
 All changes to this collection will be documented in this file.
 
+## [7.21.x] - June 22, 2021
+* Allow to set timeout to download tar file
+
 ## [7.19.8] - June 10, 2021
 * Fix Missioncontrol ES start issue
 

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/defaults/main.yml
@@ -91,3 +91,5 @@ artifactory_systemyaml: |-
 
 # Note: artifactory_systemyaml_override is by default false,  if you want to change default artifactory_systemyaml
 artifactory_systemyaml_override: false
+
+download_timeout: 10

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -36,17 +36,29 @@
 
 - name: Download artifactory
   become: yes
+  get_url:
+    url: "{{ artifactory_tar }}"
+    dest: "{{ jfrog_home_directory }}"
+    owner: "{{ artifactory_user }}"
+    group: "{{ artifactory_group }}"
+    timeout: "{{ download_timeout }}"
+  when: artifactory_tar is defined
+  register: downloadartifactory
+  until: downloadartifactory is succeeded
+  retries: 3
+
+- name: uncompress artifactory
+  become: yes
   unarchive:
-    src: "{{ artifactory_tar }}"
+    src: "{{ downloadartifactory.dest }}"
     dest: "{{ jfrog_home_directory }}"
     remote_src: yes
     owner: "{{ artifactory_user }}"
     group: "{{ artifactory_group }}"
     creates: "{{ artifactory_untar_home }}"
-  when: artifactory_tar is defined
-  register: downloadartifactory
-  until: downloadartifactory is succeeded
-  retries: 3
+  when: 
+  - artifactory_tar is defined
+  - downloadartifactory is succeeded
 
 - name: Check if app directory exists
   become: yes

--- a/Ansible/ansible_collections/jfrog/platform/roles/distribution/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/distribution/defaults/main.yml
@@ -69,3 +69,5 @@ distribution_systemyaml: |-
 
 # Note: distribution_systemyaml_override is by default false,  if you want to change default distribution_systemyaml
 distribution_systemyaml_override: false
+
+download_timeout: 10

--- a/Ansible/ansible_collections/jfrog/platform/roles/distribution/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/distribution/tasks/install.yml
@@ -37,16 +37,28 @@
 
 - name: Download distribution
   become: yes
+  get_url:
+    url: "{{ distribution_tar }}"
+    dest: "{{ jfrog_home_directory }}"
+    owner: "{{ distribution_user }}"
+    group: "{{ distribution_group }}"
+    timeout: "{{ download_timeout }}"
+  register: downloaddistribution
+  until: downloaddistribution is succeeded
+  retries: 3
+
+- name: uncompress distribution
+  become: yes
   unarchive:
-    src: "{{ distribution_tar }}"
+    src: "{{ downloaddistribution.dest }}"
     dest: "{{ jfrog_home_directory }}"
     remote_src: yes
     owner: "{{ distribution_user }}"
     group: "{{ distribution_group }}"
     creates: "{{ distribution_untar_home }}"
-  register: downloaddistribution
-  until: downloaddistribution is succeeded
-  retries: 3
+  when:
+  - distribution_tar is defined
+  - downloaddistribution is succeeded
 
 - name: Check if app directory exists
   become: yes

--- a/Ansible/ansible_collections/jfrog/platform/roles/missioncontrol/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/missioncontrol/defaults/main.yml
@@ -98,3 +98,5 @@ mc_systemyaml: |-
 
 # Note: mc_systemyaml_override is by default false,  if you want to change default mc_systemyaml
 mc_systemyaml_override: false
+
+download_timeout: 10

--- a/Ansible/ansible_collections/jfrog/platform/roles/missioncontrol/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/missioncontrol/tasks/install.yml
@@ -37,16 +37,28 @@
 
 - name: Download mc
   become: yes
+  get_url:
+    url: "{{ mc_tar }}"
+    dest: "{{ jfrog_home_directory }}"
+    owner: "{{ mc_user }}"
+    group: "{{ mc_group }}"
+    timeout: "{{ download_timeout }}"
+  register: downloadmc
+  until: downloadmc is succeeded
+  retries: 3
+
+- name: uncompress mc
+  become: yes
   unarchive:
-    src: "{{ mc_tar }}"
+    src: "{{ downloadmc.dest }}"
     dest: "{{ jfrog_home_directory }}"
     remote_src: yes
     owner: "{{ mc_user }}"
     group: "{{ mc_group }}"
     creates: "{{ mc_untar_home }}"
-  register: downloadmc
-  until: downloadmc is succeeded
-  retries: 3
+  when:
+  - mc_tar is defined
+  - downloadmc is succeeded
 
 - name: Check if app directory exists
   become: yes

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/defaults/main.yml
@@ -107,3 +107,5 @@ xray_systemyaml: |-
 
 # Note: xray_systemyaml_override is by default false,  if you want to change default xray_systemyaml
 xray_systemyaml_override: false
+
+download_timeout: 10

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/install.yml
@@ -40,16 +40,28 @@
 
 - name: Download xray
   become: yes
+  get_url:
+    url: "{{ xray_tar }}"
+    dest: "{{ jfrog_home_directory }}"
+    owner: "{{ xray_user }}"
+    group: "{{ xray_group }}"
+    timeout: "{{ download_timeout }}"
+  register: downloadxray
+  until: downloadxray is succeeded
+  retries: 3
+
+- name: uncompress xray
+  become: yes
   unarchive:
-    src: "{{ xray_tar }}"
+    src: "{{ downloadxray.dest }}"
     dest: "{{ jfrog_home_directory }}"
     remote_src: yes
     owner: "{{ xray_user }}"
     group: "{{ xray_group }}"
     creates: "{{ xray_untar_home }}"
-  register: downloadxray
-  until: downloadxray is succeeded
-  retries: 3
+  when:
+  - xray_tar is defined
+  - downloadxray is succeeded
 
 - name: Check if app directory exists
   become: yes


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: modify the way to download the tar file to allow customize the download timeout since in case a proxy is used the download takes more time to download and get timeout error


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:
In order to control more config for the downloads get_url/uri should be use as recommended [here](https://github.com/ansible/ansible/pull/32788#issuecomment-543800435) instead of using unarchive.

