### PR TITLE
[ansible/artifactory] Configures SELinux context for RHEL systems (fixes: #157)

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/RedHat.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/RedHat.yml
@@ -5,6 +5,7 @@
     state: present
 
 - name: Configure SELinux context 
+  become: yes
   sefcontext:
     target: "{{jfrog_home_directory}}/artifactory/app/bin(/.*)?"
     setype: bin_t

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -174,9 +174,10 @@
   notify: restart artifactory
 
 - name: Run restore context to reload selinux
+  become: yes
   shell: restorecon -R -v {{jfrog_home_directory}}/artifactory/app/bin
   when: ansible_distribution == 'RedHat'
-  
+
 - name: Create artifactory service
   become: yes
   command: "{{ artifactory_home }}/app/bin/installService.sh"


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Configures the Artifactory bin directory with 'bin_t' SELinux context on RHEL.  This prevents issues from running executables with SELinux set to enforcing

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #157  


**Special notes for your reviewer**:

