### PR TITLE
[ansible/artifactory] Performance improvement for permission check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 ./idea
 .idea/
 .DS_Store
-
+*.tar.gz

--- a/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
+++ b/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Platform Ansible Collection Changelog
 All changes to this collection will be documented in this file.
 
+## [10.3.0] - Feb 07, 2022
+* Performance improvement when correcting permission caused by filestorage located in 'jfrog_home_directory'
+
 ## [10.2.0] - Jan 31, 2022
 * Product Updates/fixes
 

--- a/Ansible/ansible_collections/jfrog/platform/galaxy.yml
+++ b/Ansible/ansible_collections/jfrog/platform/galaxy.yml
@@ -9,7 +9,7 @@ namespace: "jfrog"
 name: "platform"
 
 # The version of the collection. Must be compatible with semantic versioning
-version: "10.2.0"
+version: "10.3.0"
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: "README.md"

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -190,12 +190,7 @@
     creates: "{{ artifactory_service_file }}"
 
 - name: Ensure permissions are correct
-  become: yes
-  file:
-    path: "{{ jfrog_home_directory }}"
-    group: "{{ artifactory_group }}"
-    owner: "{{ artifactory_user }}"
-    recurse: yes
+  include_tasks: shared/ensure_permissions_correct.yml
 
 - name: Restart artifactory
   meta: flush_handlers

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/shared/ensure_permissions_correct.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/shared/ensure_permissions_correct.yml
@@ -2,7 +2,11 @@
   become: yes
   block:
     - name: Ensure user ownership
-      command: find {{ jfrog_home_directory }} ! -user {{ artifactory_user }} -exec chown {{ artifactory_user }} {} \;
+      ansible.builtin.command: find {{ jfrog_home_directory }} ! -user {{ artifactory_user }} -print -exec chown {{ artifactory_user }} {} \;
+      register: user_ownerships
+      changed_when: user_ownerships.stdout_lines | length > 0
 
     - name: Ensure group ownership
-      command: find {{ jfrog_home_directory }} ! -group {{ artifactory_group }} -exec chgrp {{ artifactory_group }} {} \;
+      ansible.builtin.command: find {{ jfrog_home_directory }} ! -group {{ artifactory_group }} -print -exec chgrp {{ artifactory_group }} {} \;
+      register: group_ownerships
+      changed_when: user_ownerships.stdout_lines | length > 0

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/shared/ensure_permissions_correct.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/shared/ensure_permissions_correct.yml
@@ -1,0 +1,8 @@
+- name: Ensure permissions are correct
+  become: yes
+  block:
+    - name: Ensure user ownership
+      command: find {{ jfrog_home_directory }} ! -user {{ artifactory_user }} -exec chown {{ artifactory_user }} {} \;
+
+    - name: Ensure group ownership
+      command: find {{ jfrog_home_directory }} ! -group {{ artifactory_group }} -exec chgrp {{ artifactory_group }} {} \;

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
@@ -126,12 +126,7 @@
   notify: restart artifactory
 
 - name: Ensure permissions are correct
-  become: yes
-  file:
-    path: "{{ jfrog_home_directory }}"
-    group: "{{ artifactory_group }}"
-    owner: "{{ artifactory_user }}"
-    recurse: yes
+  include_tasks: shared/ensure_permissions_correct.yml
 
 - name: Restart artifactory
   meta: flush_handlers


### PR DESCRIPTION
#### PR Checklist
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [x] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:

The task "Ensure permissions are correct" is very slow on systems with local binary storage containing a lot of files, especially when upgrading (~200k files lasts ~40 minutes) . Therefor a shared task was created, is searching/correcting correct ownership for files/directories in "jfrog_home_directory" having wrong permissions.

**Special notes for your reviewer**:

