### PR TITLE
[ansible/artifactory] Change the license file name based on artifactory_ha_enabled

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
+++ b/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Platform Ansible Collection Changelog
 All changes to this collection will be documented in this file.
 
+## [TBD]
+* Set license file name based on HA or standalone [GH-193](https://github.com/jfrog/JFrog-Cloud-Installers/pull/193)
+
 ## [10.1.2] - Dec 23, 2021
 * Product Updates/fixes
 

--- a/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
+++ b/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
@@ -2,7 +2,7 @@
 All changes to this collection will be documented in this file.
 
 ## [TBD]
-* Set license file name based on HA or standalone [GH-193](https://github.com/jfrog/JFrog-Cloud-Installers/pull/193)
+* Set license file name based on HA or standalone [GH-197](https://github.com/jfrog/JFrog-Cloud-Installers/pull/197)
 
 ## [10.1.2] - Dec 23, 2021
 * Product Updates/fixes

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -147,11 +147,17 @@
     - artifactory_binarystore | length > 0
   notify: restart artifactory
 
+- name: Set artifactory license file name for HA license
+  set_fact:
+     __artifactory_license_file: "artifactory.cluster.license"
+  when:
+    - artifactory_ha_enabled is true
+
 - name: Configure artifactory license(s)
   become: yes
   template:
     src: artifactory.cluster.license.j2
-    dest: "{{ artifactory_home }}/var/etc/artifactory/artifactory.cluster.license"
+    dest: "{{ artifactory_home }}/var/etc/artifactory/{{ __artifactory_license_file }}"
     mode: 0644
   when:
    - artifactory_licenses is defined

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/vars/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/vars/main.yml
@@ -3,3 +3,5 @@ platform_collection_version: 10.1.2
 
 # indicates where this collection was downloaded from (galaxy, automation_hub, standalone)
 ansible_marketplace: galaxy
+
+__artifactory_license_file: artifactory.lic


### PR DESCRIPTION
#### PR Checklist
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [X] CHANGELOG.md updated

**What this PR does / why we need it**:

Defaults the license file to `artifactory.lic` and switches it to  `artifactory.cluster.license` when the `artifactory_ha_enabled` is set to true.