### PR TITLE
Artifactory - Add support for default database driver

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -158,10 +158,18 @@
    - artifactory_licenses | length > 0
   notify: restart artifactory
 
+- name: Check if included database driver is the correct version
+  become: yes
+  stat:
+    path: "{{ artifactory_home }}/app/artifactory/tomcat/lib/postgresql-{{ postgres_driver_version }}.jar"
+  register: included_database_driver
+
 - name: Check if database driver exists
   become: yes
   stat:
     path: "{{ artifactory_home }}/app/artifactory/tomcat/lib/jf_postgresql-{{ postgres_driver_version }}.jar"
+  when: 
+    - not included_database_driver.stat.exists
   register: database_driver
 
 - name: Download database driver
@@ -174,6 +182,7 @@
   when:
     - postgres_driver_download_url is defined
     - not database_driver.stat.exists
+    - not included_database_driver.stat.exists
   notify: restart artifactory
 
 - name: Run restore context to reload selinux


### PR DESCRIPTION
add task to compare the provided database driver, with version defined
add check for the next two tasks, custom postgres driver, or downloading
from the web.

this will allow the play to work on machines that don't have full access
to the internet

zachary.wayer@garmin.com

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR improves the ability to run the ansible artifactory installer on servers that don't have full access to the internet by allowing the play to utilize the Postgres driver that is included with the jfrog-artifactory tar.gz

**Special notes for your reviewer**:
This is my first time participating in a project like this, please let me know if I should have gone about addressing these changes differently. Thank you!
