### PR TITLE
[ansible/artifactory] add more options for artifactory nginx config

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/README.md
@@ -3,3 +3,6 @@ This role installs NGINX for artifactory. This role is automatically called by t
 
 ## Role Variables
 * _server_name_: **mandatory** This is the server name. eg. "artifactory.54.175.51.178.xip.io"
+* _nginx_worker_processes_: The worker_processes configuration for nginx. Defaults to 1.
+* _artifactory_proxy_extra_config_: Enables adding extra options to the reverse proxy to artifactory.
+* _replicator_enabled_: Whether or not to include the replicator location block. Defaults to `false`.

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/defaults/main.yml
@@ -6,3 +6,8 @@ server_name: test.artifactory.com
 nginx_daemon: nginx
 
 nginx_worker_processes: 1
+
+artifactory_proxy_extra_config: |-
+  proxy_read_timeout  2400s;
+
+replicator_enabled: false

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/templates/artifactory.conf.j2
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/templates/artifactory.conf.j2
@@ -24,7 +24,7 @@
   chunked_transfer_encoding on;
   client_max_body_size 0;
   location / {
-  proxy_read_timeout  2400s;
+  {{ artifactory_proxy_extra_config }}
   proxy_pass_header   Server;
   proxy_cookie_path   ~*^/.* /;
   proxy_pass          "http://artifactory";
@@ -39,5 +39,13 @@
   location ~ ^/artifactory/ {
     proxy_pass    http://artifactory-direct;
     }
+  {% if replicator_enabled -%}
+  location /replicator/ {
+    proxy_http_version 1.1;
+    chunked_transfer_encoding on;
+    proxy_buffering off;
+    proxy_pass    http://replicator/;
+    }
+  {% endif -%}
   }
 }

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/README.md
@@ -6,3 +6,5 @@ The artifactory_nginx_ssl role installs and configures nginx for SSL.
 * _certificate_: This is the SSL cert.
 * _certificate_key_: This is the SSL private key.
 * _nginx_worker_processes_: The worker_processes configuration for nginx. Defaults to 1.
+* _artifactory_proxy_extra_config_: Enables adding extra options to the reverse proxy to artifactory.
+* _replicator_enabled_: Whether or not to include the replicator location block. Defaults to `false`.

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/defaults/main.yml
@@ -8,3 +8,8 @@ nginx_daemon: nginx
 redirect_http_to_https_enabled: true
 
 nginx_worker_processes: 1
+
+artifactory_proxy_extra_config: |-
+  proxy_read_timeout  2400s;
+
+replicator_enabled: false

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/templates/artifactory.conf.j2
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/templates/artifactory.conf.j2
@@ -29,7 +29,7 @@
   chunked_transfer_encoding on;
   client_max_body_size 0;
   location / {
-  proxy_read_timeout  2400s;
+  {{ artifactory_proxy_extra_config }}
   proxy_pass_header   Server;
   proxy_cookie_path   ~*^/.* /;
   proxy_pass          "http://artifactory";
@@ -44,5 +44,13 @@
   location ~ ^/artifactory/ {
     proxy_pass    http://artifactory-direct;
     }
+  {% if replicator_enabled -%}
+  location /replicator/ {
+    proxy_http_version 1.1;
+    chunked_transfer_encoding on;
+    proxy_buffering off;
+    proxy_pass    http://replicator/;
+    }
+  {% endif -%}
   }
 }


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [x] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
* allows adding the JFrog-prescribed nginx config when the Artifactory replicator is enabled: https://www.jfrog.com/confluence/display/JFROG/Replicator#Replicator-WorkingwithReverseProxy
* allows adding extra nginx config options to the `/` location block
* is backward-compatible

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

