### PR TITLE
[ansible/artifactory] Added "installService.sh" after upgrading Artifactory

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/handlers/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/handlers/main.yml
@@ -5,6 +5,7 @@
   systemd:
     name: "{{ artifactory_daemon }}"
     state: restarted
+    daemon_reload: yes
 
 - name: stop artifactory
   become: yes

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/shared/install_service.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/shared/install_service.yml
@@ -1,0 +1,6 @@
+---
+- name: Create artifactory service
+  become: yes
+  command: "{{ artifactory_home }}/app/bin/installService.sh"
+  args:
+    creates: "{{ artifactory_service_file }}"

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -188,11 +188,8 @@
 - name: Restore SELinux content
   include_tasks: shared/selinux_restore_context.yml
 
-- name: Create artifactory service
-  become: yes
-  command: "{{ artifactory_home }}/app/bin/installService.sh"
-  args:
-    creates: "{{ artifactory_service_file }}"
+- name: Install Service
+  include_tasks: shared/install_service.yml
 
 - name: Ensure permissions are correct
   include_tasks: shared/ensure_permissions_correct.yml

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
@@ -118,6 +118,9 @@
     - artifactory_systemyaml_override or (not systemyaml.stat.exists)
   notify: restart artifactory
 
+- name: Install Service
+  include_tasks: shared/install_service.yml
+
 - name: Restore SELinux content
   include_tasks: shared/selinux_restore_context.yml
 


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

We faced the issue following Issue (https://www.jfrog.com/jira/browse/RTFACT-27237) on our Artifactory Installation which is maintained through Ansible. After Nir published the Article on this (https://jfrog.com/knowledge-base/artifactory-why-does-my-linux-archive-service-installation-fail-degrade-after-an-upgrade/) I was wondering why Ansible would not Call `installService.sh` as part of the upgrade Process.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

[RTFACT-27237 on JIRA](https://www.jfrog.com/jira/browse/RTFACT-27237)
