### PR TITLE
[ansible] Update RedHat Nginx installer tasks to use HTTPS URLs

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/tasks/RedHat.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/tasks/RedHat.yml
@@ -14,7 +14,7 @@
     content: |
         [nginx-stable]
         name=nginx stable repo
-        baseurl=http://nginx.org/packages/{{ (ansible_distribution == 'Amazon')|ternary('amzn2','centos') }}/$releasever/$basearch/
+        baseurl=https://nginx.org/packages/{{ (ansible_distribution == 'Amazon')|ternary('amzn2','centos') }}/$releasever/$basearch/
         gpgcheck=1
         enabled=1
         gpgkey=https://nginx.org/keys/nginx_signing.key

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/tasks/RedHat.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/tasks/RedHat.yml
@@ -14,7 +14,7 @@
     content: |
         [nginx-stable]
         name=nginx stable repo
-        baseurl=http://nginx.org/packages/{{ (ansible_distribution == 'Amazon')|ternary('amzn2','centos') }}/$releasever/$basearch/
+        baseurl=https://nginx.org/packages/{{ (ansible_distribution == 'Amazon')|ternary('amzn2','centos') }}/$releasever/$basearch/
         gpgcheck=1
         enabled=1
         gpgkey=https://nginx.org/keys/nginx_signing.key


### PR DESCRIPTION

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:  Corporate firewalls are now limiting access to HTTP URLs. The Debian tasks already point to HTTPS URLs for the Nginx installer, RedHat should also point towards HTTPS, in my opinion. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**: This will help us complete a POC we have with JFrog.

