### PR TITLE
[Ansible/Artifactory] -Upgrade play to stop artifactory service 

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
@@ -27,6 +27,7 @@
     owner: "{{ artifactory_user }}"
     group: "{{ artifactory_group }}"
     creates: "{{ artifactory_untar_home }}"
+    notify: stop artifactory
   when: (download_artifactory is succeeded) and (not ansible_check_mode)
 
 - name: Stop artifactory

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
@@ -27,7 +27,7 @@
     owner: "{{ artifactory_user }}"
     group: "{{ artifactory_group }}"
     creates: "{{ artifactory_untar_home }}"
-    notify: stop artifactory
+  notify: stop artifactory
   when: (download_artifactory is succeeded) and (not ansible_check_mode)
 
 - name: Stop artifactory


### PR DESCRIPTION
When running the upgrade play the stop artifactory is never notified. So running flush_handlers never actually gets hit.

Add notify to unarchive task, with the idea being if you're unarchiving a new version this means that host will be taking an update.

zachary.wayer@garmin.com

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
When running the upgrade play the stop artifactory is never notified. So running flush_handlers never actually gets hit.

Add notify to unarchive task, with the idea being if you're unarchiving a new version this means that host will be taking an update.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

