### PR TITLE
[ansible/artifactory] Conditionally start Artifactory service

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/defaults/main.yml
@@ -98,3 +98,5 @@ artifactory_systemyaml: |-
 
 # Note: artifactory_systemyaml_override is by default false,  if you want to change default artifactory_systemyaml
 artifactory_systemyaml_override: false
+
+artifactory_start_service: true

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/handlers/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/handlers/main.yml
@@ -6,6 +6,8 @@
     name: "{{ artifactory_daemon }}"
     state: restarted
     daemon_reload: true
+  when:
+    - artifactory_start_service
 
 - name: Stop artifactory
   become: true

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -197,6 +197,8 @@
 
 - name: Restart artifactory
   ansible.builtin.meta: flush_handlers
+  when:
+    - artifactory_start_service
 
 - name: Make sure artifactory is up and running
   ansible.builtin.uri:
@@ -207,4 +209,6 @@
   until: result is succeeded
   retries: 25
   delay: 5
-  when: not ansible_check_mode
+  when:
+    - not ansible_check_mode
+    - artifactory_start_service


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
In my use case I build an AMI image of artifactory host. 
The role starts Artifactory service unconditionally,  which is harmful in my case, because
Artifactory process connects to existing database and may perform an unwanted database migration.

This PR adds a variable `artifactory_start_service` that defaults to true.
When set to false, it prevents handlers from starting Artifactory and skips the health check at the end.
