### PR TITLE
[ansible/artifactory] Allow overriding nginx config templates

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/defaults/main.yml
@@ -7,3 +7,6 @@ nginx_daemon: nginx
 
 nginx_worker_processes: 1
 artifactory_docker_registry_subdomain: false
+
+artifactory_conf_template: artifactory.conf.j2
+nginx_conf_template: nginx.conf.j2

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/tasks/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Copy nginx.conf file
   become: true
   ansible.builtin.template:
-    src: nginx.conf.j2
+    src: "{{ nginx_conf_template }}"
     dest: /etc/nginx/nginx.conf
     owner: root
     group: root
@@ -23,7 +23,7 @@
 - name: Generate artifactory.conf
   become: true
   ansible.builtin.template:
-    src: artifactory.conf.j2
+    src:  "{{ artifactory_conf_template }}"
     dest: /etc/nginx/conf.d/artifactory.conf
     owner: root
     group: root

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/tasks/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: Generate artifactory.conf
   become: true
   ansible.builtin.template:
-    src:  "{{ artifactory_conf_template }}"
+    src: "{{ artifactory_conf_template }}"
     dest: /etc/nginx/conf.d/artifactory.conf
     owner: root
     group: root

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/defaults/main.yml
@@ -9,3 +9,6 @@ redirect_http_to_https_enabled: true
 
 nginx_worker_processes: 1
 artifactory_docker_registry_subdomain: false
+
+artifactory_conf_template: artifactory.conf.j2
+nginx_conf_template: nginx.conf.j2

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/tasks/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/tasks/main.yml
@@ -63,6 +63,7 @@
     dest: "/var/opt/jfrog/nginx/ssl/cert.pem"
     mode: 0644
   notify: Restart nginx
+  no_log: true
 
 - name: Ensure pki exists
   become: true
@@ -78,6 +79,7 @@
     dest: "/etc/pki/tls/cert.key"
     mode: 0644
   notify: Restart nginx
+  no_log: true
 
 - name: Restart nginx
   ansible.builtin.meta: flush_handlers

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/tasks/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: Configure main nginx conf file.
   become: true
   ansible.builtin.template:
-    src: nginx.conf.j2
+    src: "{{ nginx_conf_template }}"
     dest: /etc/nginx/nginx.conf
     owner: root
     group: root
@@ -42,7 +42,7 @@
 - name: Configure the artifactory nginx conf
   become: true
   ansible.builtin.template:
-    src: artifactory.conf.j2
+    src: "{{ artifactory_conf_template }}"
     dest: /etc/nginx/conf.d/artifactory.conf
     owner: root
     group: root


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md


**What this PR does / why we need it**:
Allow overriding the templates for nginx configs for `artifactory_nginx` and  `artifactory_nginx_ssl` roles.
This would allow configuring features like proxy timeouts, log formats, real ip module configs which are needed in production environments. 

Apart from that, currently TLS certificate and key are printed to ansible logs, which is a big security concern.
