### PR TITLE
[ansible/artifactory] Fix for #267 hard-coded path.

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
+++ b/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
@@ -1,6 +1,8 @@
 # JFrog Platform Ansible Collection Changelog
 All changes to this collection will be documented in this file.
 
+## [10.12.0] - Mar 12, 2023
+* Adding variables for certificate and key paths.
 ## [10.12.0] - Mar 1, 2023
 * Conditionally start Artifactory service [GH-260](https://github.com/jfrog/JFrog-Cloud-Installers/pull/260)
 * Allow overriding nginx config templates [GH-261](https://github.com/jfrog/JFrog-Cloud-Installers/pull/261)
@@ -154,7 +156,7 @@ All changes to this collection will be documented in this file.
 ## [7.25.7] - Sep 16, 2021
 * Bug Fixes
 
-## [7.24.3] - Aug 17, 2021 
+## [7.24.3] - Aug 17, 2021
 * Added required variables check when using `artifactory_nginx_ssl` role
 * Missioncontrol's Elasticsearch to use default ES JAVA_HOME
 * Bug Fixes
@@ -194,4 +196,4 @@ All changes to this collection will be documented in this file.
 * Added new `groups_vars/all/package_version.yml` file to define product versions
 * Added global support for masterKey and joinKey values in `groups_vars/all/vars.yml`
 * **IMPORTANT**
-* Previous 1.x.x jfrog.installer [deprecated collection](https://github.com/jfrog/JFrog-Cloud-Installers/tree/ansible-v1.1.2/Ansible/ansible_collections/jfrog/installers) 
+* Previous 1.x.x jfrog.installer [deprecated collection](https://github.com/jfrog/JFrog-Cloud-Installers/tree/ansible-v1.1.2/Ansible/ansible_collections/jfrog/installers)

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/defaults/main.yml
@@ -12,3 +12,6 @@ artifactory_docker_registry_subdomain: false
 
 artifactory_conf_template: artifactory.conf.j2
 nginx_conf_template: nginx.conf.j2
+
+ssl_certificate_path: /etc/pki/tls/certs
+ssl_certificate_key_path: /etc/pki/tls/private

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/tasks/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/tasks/main.yml
@@ -56,31 +56,37 @@
     state: directory
     mode: 0755
 
+- name: Ensure ssl_certificate_path exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ ssl_certificate_path }}"
+    state: directory
+    mode: 0755
+
+- name: Ensure ssl_certificate_key_path exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ ssl_certificate_key_path }}"
+    state: directory
+    mode: 0700
+
 - name: Configure certificate
   become: true
   ansible.builtin.template:
     src: certificate.pem.j2
-    dest: "/var/opt/jfrog/nginx/ssl/cert.pem"
+    dest: "{{ ssl_certificate_path }}/cert.pem"
     mode: 0644
   notify: Restart nginx
   no_log: true
-
-- name: Ensure pki exists
-  become: true
-  ansible.builtin.file:
-    path: "/etc/pki/tls"
-    state: directory
-    mode: 0755
 
 - name: Configure key
   become: true
   ansible.builtin.template:
     src: certificate.key.j2
-    dest: "/etc/pki/tls/cert.key"
-    mode: 0644
+    dest: "{{ ssl_certificate_key_path }}/cert.key"
+    mode: 0600
   notify: Restart nginx
   no_log: true
-  
 
 - name: Restart nginx
   ansible.builtin.meta: flush_handlers

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/templates/artifactory.conf.j2
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/templates/artifactory.conf.j2
@@ -10,8 +10,8 @@
   server 127.0.0.1:8081;
 }
   ssl_protocols TLSv1.1 TLSv1.2;
-  ssl_certificate      /var/opt/jfrog/nginx/ssl/cert.pem;
-  ssl_certificate_key  /etc/pki/tls/cert.key;
+  ssl_certificate      {{ ssl_certificate_path }}/cert.pem;
+  ssl_certificate_key  {{ ssl_certificate_key_path }}/cert.key;
   ssl_session_cache shared:SSL:1m;
   ssl_prefer_server_ciphers   on;
   ## server configuration


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [X] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

The artifactory_nginx_ssl role used hard-coded paths for certificates and keys (based on Debian/Ubuntu). This change introduces two variables for two directories with appropriate file permissions. We need this to run Artifactory on a CIS compliant RHEL8 server.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #267


**Special notes for your reviewer**:

