### PR TITLE
[ansible/xray] Conditionally start Xray service

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/defaults/main.yml
@@ -102,3 +102,5 @@ xray_systemyaml: |-
 
 # Note: xray_systemyaml_override is by default false,  if you want to change default xray_systemyaml
 xray_systemyaml_override: false
+
+xray_start_service: true

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/handlers/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/handlers/main.yml
@@ -5,6 +5,8 @@
   ansible.builtin.systemd:
     name: "{{ xray_daemon }}"
     state: restarted
+  when:
+  - xray_start_service
 
 - name: Stop xray
   become: true

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/install.yml
@@ -166,6 +166,8 @@
 
 - name: Restart xray
   ansible.builtin.meta: flush_handlers
+  when:
+  - xray_start_service
 
 - name: Make sure xray is up and running
   ansible.builtin.uri:
@@ -176,4 +178,6 @@
   until: result is succeeded
   retries: 25
   delay: 5
-  when: not ansible_check_mode
+  when:
+  - not ansible_check_mode
+  - xray_start_service

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/upgrade.yml
@@ -123,6 +123,9 @@
 
 - name: Restart xray
   ansible.builtin.meta: flush_handlers
+  when:
+  - xray_start_service
+
 
 - name: Make sure xray is up and running
   ansible.builtin.uri:
@@ -133,4 +136,6 @@
   until: result is succeeded
   retries: 25
   delay: 5
-  when: not ansible_check_mode
+  when:
+  - not ansible_check_mode
+  - xray_start_service


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
In my use case I build an AMI image of Xray host. 
The role starts Xray service unconditionally,  which is harmful in my case, because
Xray process connects to existing database and may perform an unwanted database migration.

This PR adds a variable `xray_start_service` that defaults to `true`.
When set to false, it prevents handlers from starting Xray and skips the health check at the end.