### PR TITLE
[ansible/artifactory, ansible/xray] Allow using crontab

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/defaults/main.yml
@@ -98,3 +98,6 @@ artifactory_systemyaml: |-
 
 # Note: artifactory_systemyaml_override is by default false,  if you want to change default artifactory_systemyaml
 artifactory_systemyaml_override: false
+
+# Allow artifactory user to create crontab rules
+artifactory_allow_crontab: false

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -42,6 +42,17 @@
     shell: /bin/bash
     state: present
 
+- name: Allow using crontab
+  ansible.builtin.lineinfile:
+    path: /etc/cron.allow
+    line: "{{ artifactory_user }}"
+    state: present
+
+- name: Allow reading cron.allow
+  file:
+    path: /etc/cron.allow
+    mode: 0644
+
 - name: Check if artifactory tar already exists
   become: true
   ansible.builtin.stat:

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -47,11 +47,13 @@
     path: /etc/cron.allow
     line: "{{ artifactory_user }}"
     state: present
+  when: artifactory_allow_crontab
 
 - name: Allow reading cron.allow
   file:
     path: /etc/cron.allow
     mode: 0644
+  when: artifactory_allow_crontab
 
 - name: Check if artifactory tar already exists
   become: true

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -50,7 +50,7 @@
   when: artifactory_allow_crontab
 
 - name: Allow reading cron.allow
-  file:
+  ansible.builtin.file:
     path: /etc/cron.allow
     mode: 0644
   when: artifactory_allow_crontab

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
@@ -9,7 +9,7 @@
   when: artifactory_allow_crontab
 
 - name: Allow reading cron.allow
-  file:
+  ansible.builtin.file:
     path: /etc/cron.allow
     mode: 0644
   when: artifactory_allow_crontab

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
@@ -1,6 +1,19 @@
 - name: Configure SELinux context
   ansible.builtin.include_tasks: shared/selinux_configure_context.yml
 
+- name: Allow using crontab
+  ansible.builtin.lineinfile:
+    path: /etc/cron.allow
+    line: "{{ artifactory_user }}"
+    state: present
+  when: artifactory_allow_crontab
+
+- name: Allow reading cron.allow
+  file:
+    path: /etc/cron.allow
+    mode: 0644
+  when: artifactory_allow_crontab
+
 - name: Check if artifactory tar already exists
   become: true
   ansible.builtin.stat:

--- a/Ansible/ansible_collections/jfrog/platform/roles/distribution/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/distribution/defaults/main.yml
@@ -70,3 +70,6 @@ distribution_systemyaml: |-
 
 # Note: distribution_systemyaml_override is by default false,  if you want to change default distribution_systemyaml
 distribution_systemyaml_override: false
+
+# Allow distribution user to create crontab rules
+distribution_allow_crontab: false

--- a/Ansible/ansible_collections/jfrog/platform/roles/distribution/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/distribution/tasks/install.yml
@@ -17,6 +17,19 @@
     shell: /bin/bash
     state: present
 
+- name: Allow using crontab
+  ansible.builtin.lineinfile:
+    path: /etc/cron.allow
+    line: "{{ distribution_user }}"
+    state: present
+  when: distribution_allow_crontab
+
+- name: Allow reading cron.allow
+  file:
+    path: /etc/cron.allow
+    mode: 0644
+  when: distribution_allow_crontab
+
 - name: Check if distribution tar already exists
   become: true
   ansible.builtin.stat:

--- a/Ansible/ansible_collections/jfrog/platform/roles/distribution/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/distribution/tasks/install.yml
@@ -25,7 +25,7 @@
   when: distribution_allow_crontab
 
 - name: Allow reading cron.allow
-  file:
+  ansible.builtin.file:
     path: /etc/cron.allow
     mode: 0644
   when: distribution_allow_crontab

--- a/Ansible/ansible_collections/jfrog/platform/roles/distribution/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/distribution/tasks/upgrade.yml
@@ -125,7 +125,7 @@
   when: distribution_allow_crontab
 
 - name: Allow reading cron.allow
-  file:
+  ansible.builtin.file:
     path: /etc/cron.allow
     mode: 0644
   when: distribution_allow_crontab

--- a/Ansible/ansible_collections/jfrog/platform/roles/distribution/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/distribution/tasks/upgrade.yml
@@ -117,6 +117,19 @@
     owner: "{{ distribution_user }}"
     group: "{{ distribution_group }}"
 
+- name: Allow using crontab
+  ansible.builtin.lineinfile:
+    path: /etc/cron.allow
+    line: "{{ distribution_user }}"
+    state: present
+  when: distribution_allow_crontab
+
+- name: Allow reading cron.allow
+  file:
+    path: /etc/cron.allow
+    mode: 0644
+  when: distribution_allow_crontab
+
 - name: Restart distribution
   ansible.builtin.meta: flush_handlers
 

--- a/Ansible/ansible_collections/jfrog/platform/roles/insight/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/insight/defaults/main.yml
@@ -85,3 +85,6 @@ insight_systemyaml: |-
 
 # Note: insight_systemyaml_override is by default false,  if you want to change default insight_systemyaml
 insight_systemyaml_override: false
+
+# Allow insight user to create crontab rules
+insight_allow_crontab: false

--- a/Ansible/ansible_collections/jfrog/platform/roles/insight/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/insight/tasks/install.yml
@@ -25,7 +25,7 @@
   when: insight_allow_crontab
 
 - name: Allow reading cron.allow
-  file:
+  ansible.builtin.file:
     path: /etc/cron.allow
     mode: 0644
   when: insight_allow_crontab

--- a/Ansible/ansible_collections/jfrog/platform/roles/insight/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/insight/tasks/install.yml
@@ -17,6 +17,19 @@
     shell: /bin/bash
     state: present
 
+- name: Allow using crontab
+  ansible.builtin.lineinfile:
+    path: /etc/cron.allow
+    line: "{{ insight_user }}"
+    state: present
+  when: insight_allow_crontab
+
+- name: Allow reading cron.allow
+  file:
+    path: /etc/cron.allow
+    mode: 0644
+  when: insight_allow_crontab
+
 - name: Check if insight tar already exists
   become: true
   ansible.builtin.stat:

--- a/Ansible/ansible_collections/jfrog/platform/roles/insight/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/insight/tasks/upgrade.yml
@@ -121,7 +121,7 @@
   when: insight_allow_crontab
 
 - name: Allow reading cron.allow
-  file:
+  ansible.builtin.file:
     path: /etc/cron.allow
     mode: 0644
   when: insight_allow_crontab

--- a/Ansible/ansible_collections/jfrog/platform/roles/insight/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/insight/tasks/upgrade.yml
@@ -113,6 +113,19 @@
     owner: "{{ insight_user }}"
     group: "{{ insight_group }}"
 
+- name: Allow using crontab
+  ansible.builtin.lineinfile:
+    path: /etc/cron.allow
+    line: "{{ insight_user }}"
+    state: present
+  when: insight_allow_crontab
+
+- name: Allow reading cron.allow
+  file:
+    path: /etc/cron.allow
+    mode: 0644
+  when: insight_allow_crontab
+
 - name: Restart insight
   ansible.builtin.meta: flush_handlers
 

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/defaults/main.yml
@@ -102,3 +102,6 @@ xray_systemyaml: |-
 
 # Note: xray_systemyaml_override is by default false,  if you want to change default xray_systemyaml
 xray_systemyaml_override: false
+
+# Allow xray user to create crontab rules
+xray_allow_crontab: false

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/install.yml
@@ -22,11 +22,13 @@
     path: /etc/cron.allow
     line: "{{ xray_user }}"
     state: present
+  when: xray_allow_crontab
 
 - name: Allow reading cron.allow
   file:
     path: /etc/cron.allow
     mode: 0644
+  when: xray_allow_crontab
 
 - name: Check if xray tar exists
   become: true

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/install.yml
@@ -25,7 +25,7 @@
   when: xray_allow_crontab
 
 - name: Allow reading cron.allow
-  file:
+  ansible.builtin.file:
     path: /etc/cron.allow
     mode: 0644
   when: xray_allow_crontab

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/install.yml
@@ -17,6 +17,17 @@
     shell: /bin/bash
     state: present
 
+- name: Allow using crontab
+  ansible.builtin.lineinfile:
+    path: /etc/cron.allow
+    line: "{{ xray_user }}"
+    state: present
+
+- name: Allow reading cron.allow
+  file:
+    path: /etc/cron.allow
+    mode: 0644
+
 - name: Check if xray tar exists
   become: true
   ansible.builtin.stat:

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/upgrade.yml
@@ -121,6 +121,19 @@
     group: "{{ xray_group }}"
     recurse: true
 
+- name: Allow using crontab
+  ansible.builtin.lineinfile:
+    path: /etc/cron.allow
+    line: "{{ xray_user }}"
+    state: present
+  when: xray_allow_crontab
+
+- name: Allow reading cron.allow
+  file:
+    path: /etc/cron.allow
+    mode: 0644
+  when: xray_allow_crontab
+
 - name: Restart xray
   ansible.builtin.meta: flush_handlers
 

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/upgrade.yml
@@ -129,7 +129,7 @@
   when: xray_allow_crontab
 
 - name: Allow reading cron.allow
-  file:
+  ansible.builtin.file:
     path: /etc/cron.allow
     mode: 0644
   when: xray_allow_crontab


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Artifactory and Xray rely on crontab to facilitate log rotation.
Current ansible roles do not configure access to crontab for users `artifactory` or `xray`. 
This results in the following errors:

```
xrayManage.sh[43290]: /etc/cron.allow: Permission denied
```

and

```
The user artifactory cannot use this program (crontab)
The user xray cannot use this program (crontab)
```

I haven't checked other products for this problem, please let me know if the fix needs to be added to other roles.
