### PR TITLE
[ansible/artifactory] Fix for #195 Allow external TLS certs

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
+++ b/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Platform Ansible Collection Changelog
 All changes to this collection will be documented in this file.
 
+## [10.12.2] - Mar 29, 2023
+* Allow using external TLS certificates [GH-278](https://github.com/jfrog/JFrog-Cloud-Installers/pull/278)
+
 ## [10.12.1] - Mar 27, 2023
 * Conditionally start Xray service [GH-275](https://github.com/jfrog/JFrog-Cloud-Installers/pull/275)
 * Set SELinux boolean httpd_can_network_connect [GH-271](https://github.com/jfrog/JFrog-Cloud-Installers/pull/271)

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/README.md
@@ -3,8 +3,11 @@ The artifactory_nginx_ssl role installs and configures nginx for SSL.
 
 ## Role Variables
 * _server_name_: This is the server name. eg. "artifactory.54.175.51.178.xip.io"
-* _certificate_: This is the SSL cert.
-* _certificate_key_: This is the SSL private key.
+* _ssl_certificate_install_: `true` - install the SSL certificate and private key. When `false` you need to manage certs yourself.  
+* _ssl_certificate_: This is the filename of the SSL certificate.
+* _ssl_certificate_path_: This is the full directory path for the SSL certificate, excluding _ssl_certificate_.
+* _ssl_certificate_key_: This is the filename of the SSL private key.
+* _ssl_certificate_key_path_: This is the full directory path for the SSL private key, excluding _ssl_certificate_key_.
 * _nginx_worker_processes_: The worker_processes configuration for nginx. Defaults to 1.
 * _artifactory_docker_registry_subdomain_: Whether to add a redirect directive to the nginx config for the use of docker
   subdomains.

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/defaults/main.yml
@@ -12,6 +12,8 @@ artifactory_docker_registry_subdomain: false
 
 artifactory_conf_template: artifactory.conf.j2
 nginx_conf_template: nginx.conf.j2
-
+ssl_certificate_install: true
 ssl_certificate_path: /etc/pki/tls/certs
+ssl_certificate: cert.pem
 ssl_certificate_key_path: /etc/pki/tls/private
+ssl_certificate_key: cert.key

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/tasks/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/tasks/main.yml
@@ -57,6 +57,7 @@
     mode: 0755
 
 - name: Ensure ssl_certificate_path exists
+  when: ssl_certificate_install
   become: true
   ansible.builtin.file:
     path: "{{ ssl_certificate_path }}"
@@ -64,6 +65,7 @@
     mode: 0755
 
 - name: Ensure ssl_certificate_key_path exists
+  when: ssl_certificate_install
   become: true
   ansible.builtin.file:
     path: "{{ ssl_certificate_key_path }}"
@@ -71,19 +73,21 @@
     mode: 0700
 
 - name: Configure certificate
+  when: ssl_certificate_install
   become: true
   ansible.builtin.template:
     src: certificate.pem.j2
-    dest: "{{ ssl_certificate_path }}/cert.pem"
+    dest: "{{ ssl_certificate_path }}/{{ ssl_certificate }}"
     mode: 0644
   notify: Restart nginx
   no_log: true
 
 - name: Configure key
+  when: ssl_certificate_install
   become: true
   ansible.builtin.template:
     src: certificate.key.j2
-    dest: "{{ ssl_certificate_key_path }}/cert.key"
+    dest: "{{ ssl_certificate_key_path }}/{{ ssl_certificate_key }}"
     mode: 0600
   notify: Restart nginx
   no_log: true

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/templates/artifactory.conf.j2
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/templates/artifactory.conf.j2
@@ -10,8 +10,8 @@
   server 127.0.0.1:8081;
 }
   ssl_protocols TLSv1.1 TLSv1.2;
-  ssl_certificate      {{ ssl_certificate_path }}/cert.pem;
-  ssl_certificate_key  {{ ssl_certificate_key_path }}/cert.key;
+  ssl_certificate      {{ ssl_certificate_path }}/{{ ssl_certificate }};
+  ssl_certificate_key  {{ ssl_certificate_key_path }}/{{ ssl_certificate_key }};
   ssl_session_cache shared:SSL:1m;
   ssl_prefer_server_ciphers   on;
   ## server configuration


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [X] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

The current role `artifactory_ginx_ssl` requires passing in variables containing:

    the TLS certificate value for the instance
    the certificate key value

This is fine if you have a self-signed (or externally signed) certificate purchased specifically for your Artifactory instance, but it doesn't work with e.g. LetsEncrypt or ZeroSSL certificates which are being renewed every 3 months asynchronously. This PR introduces variables to be able to use an external process. The default value, `ssl_certificate_install: true`, continues to install the SSL certificate and private key. Setting this to `false` avoids the race-conditions on these files.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #195


**Special notes for your reviewer**:

2 other variables are introduced and described in the README to allow tuning the external process. 
