### PR TITLE
[ansible/artifactory] Fix for #281 restore SELinux context on bin directory on RedHat-like distros

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
+++ b/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this collection will be documented in this file.
 ## [10.12.3] - May 11, 2023
 
 * Allow using external TLS certificates [GH-278](https://github.com/jfrog/JFrog-Cloud-Installers/pull/278)
+* Fix for SELinux context on bin directory [GH-282](https://github.com/jfrog/JFrog-Cloud-Installers/pull/282)
 
 ## [10.12.2] - May 2, 2023
 * Product Updates/fixes

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/shared/selinux_restore_context.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/shared/selinux_restore_context.yml
@@ -2,5 +2,5 @@
 - name: Restore SELinux content
   become: true
   ansible.builtin.command: restorecon -R -v "{{ jfrog_home_directory }}/artifactory/app/bin"
-  when: ansible_distribution == 'RedHat'
+  when: ansible_os_family == 'RedHat'
   changed_when: false


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [X] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Fixes an SELinux issue on AlmaLinux 8 (and probably Rocky/Oracle/Fedora)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #281


**Special notes for your reviewer**:
Check /var/log/messages on AlmaLinux8

