### PR TITLE
[ansible/artifactory] Fix for #284 - Updating flag handler to be boolean

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/handlers/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/handlers/main.yml
@@ -7,7 +7,7 @@
     state: restarted
     daemon_reload: true
   when:
-    - artifactory_start_service
+    - artifactory_start_service | bool
 
 - name: Stop artifactory
   become: true

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -198,7 +198,7 @@
 - name: Restart artifactory
   ansible.builtin.meta: flush_handlers
   when:
-    - artifactory_start_service
+    - artifactory_start_service 
 
 - name: Make sure artifactory is up and running
   ansible.builtin.uri:
@@ -211,4 +211,4 @@
   delay: 5
   when:
     - not ansible_check_mode
-    - artifactory_start_service
+    - artifactory_start_service | bool

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -198,7 +198,7 @@
 - name: Restart artifactory
   ansible.builtin.meta: flush_handlers
   when:
-    - artifactory_start_service 
+    - artifactory_start_service
 
 - name: Make sure artifactory is up and running
   ansible.builtin.uri:

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
@@ -141,7 +141,7 @@
 - name: Restart artifactory
   ansible.builtin.meta: flush_handlers
   when:
-    - artifactory_start_service
+    - artifactory_start_service 
 
 - name: Make sure artifactory is up and running
   ansible.builtin.uri:
@@ -154,4 +154,4 @@
   delay: 5
   when:
     - not ansible_check_mode
-    - artifactory_start_service
+    - artifactory_start_service | bool

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
@@ -141,7 +141,7 @@
 - name: Restart artifactory
   ansible.builtin.meta: flush_handlers
   when:
-    - artifactory_start_service 
+    - artifactory_start_service
 
 - name: Make sure artifactory is up and running
   ansible.builtin.uri:


### PR DESCRIPTION
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

 Title of the PR starts with installer/product name (e.g. [ansible/artifactory])
 CHANGELOG.md updated
 Variables and other changes are documented in the README.md
What this PR does / why we need it:
Found a recent MR in the master branch that wasn't working as expected. The addition of the 'artifactory_start_serviceseemed to be not working as expected when trying to use it to build an AWS AMI image, where the service should not start.  Instead, the Ansible portion was failing because the playbook/role was still trying to start the Artifactory image when artifactory_start_service was defined as 'false'.  Adding the| bool` to the playbook allowed it to skip the startup and subsequent restart of the Arifactory service when passed in an AMI creation task.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes https://github.com/jfrog/JFrog-Cloud-Installers/issues/284

Special notes for your reviewer:
@alexhung @hexa2k9 @yoav @freddy33 @diginc