### PR TITLE
[ansible/artifactory] Fix for #298 redirect http to https

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/files/redirect_http_to_https.conf
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/files/redirect_http_to_https.conf
@@ -1,5 +1,8 @@
 server {
-    listen 80;
-    server_name _;
-    return 301 https://$host$request_uri;
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    location / {
+        return 301 https://$host/$request_uri;
+    }
 }


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [X] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Without this fix a http request gets the default Nginx page instead of the Artifactory UI.
Configuration no follows Mozilla SSL Configurator.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #298


**Special notes for your reviewer**:
See also the Mozilla TLS configuration tool: [https://ssl-config.mozilla.org](https://ssl-config.mozilla.org/#server=nginx&version=1.24.0&config=intermediate&openssl=1.1.1k&ocsp=false&guideline=5.7)
