### PR TITLE
[ansible/artifactory] Fix for #307 artifactory service stopping

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/shared/install_service.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/shared/install_service.yml
@@ -2,3 +2,4 @@
 - name: Create artifactory service
   become: true
   ansible.builtin.command: "{{ artifactory_home }}/app/bin/installService.sh"
+  notify: Restart artifactory

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/shared/install_service.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/shared/install_service.yml
@@ -1,5 +1,9 @@
 ---
+- name: Get service facts
+  ansible.builtin.service_facts:
+
 - name: Create artifactory service
   become: true
   ansible.builtin.command: "{{ artifactory_home }}/app/bin/installService.sh"
+  when: ansible_facts.services['artifactory.service'] is not defined
   notify: Restart artifactory


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This MR makes the "Create artifactory service" task notify the "Restart artifactory" handler. Since the "Create artifactory service" task stops the artifactory service if it is running, this change ensures the service gets up and running again.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #307 


**Special notes for your reviewer**:
In addition to this change, skipping the "Create artifactory service" task would be great if the service is already installed; however, I'm unsure how to check for that.