### PR TITLE
[ansible/artifactory] Fixes #324 double slash when redirecting from http to https

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
+++ b/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Platform Ansible Collection Changelog
 All changes to this collection will be documented in this file.
 
+## [10.14.8] - Aug 23, 2023
+* Fixed - http to https redirect with nginx get double slash [GH-324](https://github.com/jfrog/JFrog-Cloud-Installers/issues/324)
+
 ## [10.14.7] - Aug 18, 2023
 * Fixed - artifactory role does not update java options during upgrade [GH-320](https://github.com/jfrog/JFrog-Cloud-Installers/issues/320)
 * Product Updates/fixes

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/files/redirect_http_to_https.conf
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/files/redirect_http_to_https.conf
@@ -3,6 +3,6 @@ server {
     listen [::]:80 default_server;
 
     location / {
-        return 301 https://$host/$request_uri;
+        return 301 https://$host$request_uri;
     }
 }


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [X] CHANGELOG.md updated

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Double slashes in the URL need to be corrected.

According to https://ssl-config.mozilla.org/#server=nginx&version=1.24.0&config=intermediate&openssl=1.1.1k&ocsp=false&guideline=5.7 mentioned in #298, one should use `return 301 https://$host$request_uri;`. However, what was added to the PR associated with #298 was `return 301 https://$host/$request_uri;` with a slash after $host, causing this issue.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #324 


**Special notes for your reviewer**:

