### PR TITLE
[ansible/artifactory] Fixes #331 Install doesn't work with non-default user and group

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/shared/install_service.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/shared/install_service.yml
@@ -1,5 +1,5 @@
 ---
 - name: Create artifactory service
   become: true
-  ansible.builtin.command: "{{ artifactory_home }}/app/bin/installService.sh"
+  ansible.builtin.command: "{{ artifactory_home }}/app/bin/installService.sh {{ artifactory_user }} {{ artifactory_group }}"
   notify: Restart artifactory

--- a/Ansible/ansible_collections/jfrog/platform/roles/distribution/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/distribution/defaults/main.yml
@@ -24,7 +24,7 @@ distribution_home: "{{ jfrog_home_directory }}/distribution"
 
 distribution_install_script_path: "{{ distribution_home }}/app/bin"
 distribution_thirdparty_path: "{{ distribution_home }}/app/third-party"
-distribution_archive_service_cmd: "{{ distribution_install_script_path }}/installService.sh"
+distribution_archive_service_cmd: "{{ distribution_install_script_path }}/installService.sh --user {{ distribution_user }} --group {{ distribution_group }}"
 distribution_service_file: /lib/systemd/system/distribution.service
 
 # distribution users and groups

--- a/Ansible/ansible_collections/jfrog/platform/roles/insight/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/insight/defaults/main.yml
@@ -24,7 +24,7 @@ insight_home: "{{ jfrog_home_directory }}/insight"
 
 insight_install_script_path: "{{ insight_home }}/app/bin"
 insight_thirdparty_path: "{{ insight_home }}/app/third-party"
-insight_archive_service_cmd: "{{ insight_install_script_path }}/installService.sh"
+insight_archive_service_cmd: "{{ insight_install_script_path }}/installService.sh --user {{ insight_user }} --group {{ insight_group }}"
 insight_service_file: /lib/systemd/system/insight.service
 
 # Insight users and groups

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/defaults/main.yml
@@ -24,7 +24,7 @@ xray_home: "{{ jfrog_home_directory }}/xray"
 
 xray_install_script_path: "{{ xray_home }}/app/bin"
 xray_thirdparty_path: "{{ xray_home }}/app/third-party"
-xray_archive_service_cmd: "{{ xray_install_script_path }}/installService.sh"
+xray_archive_service_cmd: "{{ xray_install_script_path }}/installService.sh --user {{ xray_user }} --group {{ xray_group }}"
 xray_service_file: /lib/systemd/system/xray.service
 
 # Xray users and groups


### PR DESCRIPTION


#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Artifactory, and probably all services, will fail to start when using a non-default value for $service_user and $service_group

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
GitHub #331 

**Special notes for your reviewer**:
I only worked on the artifactory part, but included the other components based on the documentation (they apparently don't use positional arguments like Artifactory's installer)
[XRay](https://jfrog.com/help/r/jfrog-installation-setup-documentation/install-xray-single-node-with-linux-archive)
[Insight](https://jfrog.com/help/r/jfrog-installation-setup-documentation/insight-single-node-linux-archive-installation)
[Distribution](https://jfrog.com/help/r/jfrog-installation-setup-documentation/mission-control-and-distribution-custom-volumes)

