### PR TITLE
[ansible/artifactory] Configure admin credentials 

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
+++ b/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
@@ -1,6 +1,10 @@
 # JFrog Platform Ansible Collection Changelog
 All changes to this collection will be documented in this file.
 
+## [10.15.1] - Oct 2, 2023
+* Configure admin password
+* Formatting README.md
+
 ## [10.15.0] - Sep 12, 2023
 * Increase heap space in artifactory java opts [GH-329](https://github.com/jfrog/JFrog-Cloud-Installers/issues/329)
 * Product Updates/fixes

--- a/Ansible/ansible_collections/jfrog/platform/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/README.md
@@ -1,29 +1,29 @@
 # JFrog Platform Ansible Collection
 
 This Ansible directory consists of the following directories that support the JFrog Platform collection.
- 
+
  * ansible_collections directory - This directory contains the Ansible collection package that has the Ansible roles for Artifactory, Distribution, Insight and Xray. See the roles README for details on the product roles and variables.
  * examples directory - This directory contains example playbooks for various architectures.
- 
+
 
  ## Getting Started
 
  ## Prerequisites
 From 10.11.x collection and above, Using fully qualified collection name (FQCN) , This is required for installing collection dependencies
 
-```
+```bash
 ansible-galaxy collection install community.postgresql community.general ansible.posix
 ```
- 
+
  1. Install this collection from Ansible Galaxy.
-    
+
     ```
     ansible-galaxy collection install jfrog.platform
     ```
-        
+
     Ensure you reference the collection in your playbook when using these roles.
-        
-    ```
+
+    ```yaml
     ---
     - hosts: artifactory_servers
       collections:
@@ -31,18 +31,18 @@ ansible-galaxy collection install community.postgresql community.general ansible
         - community.general
       roles:
         - artifactory
-    
+
     ```
-    
- 2. Ansible uses SSH to connect to hosts. Ensure that your SSH private key is on your client and the public keys are installed on your Ansible hosts. 
- 
+
+ 2. Ansible uses SSH to connect to hosts. Ensure that your SSH private key is on your client and the public keys are installed on your Ansible hosts.
+
  3. Create your inventory file. Use one of the examples from the examples directory to construct an inventory file (hosts.ini) with the host addresses
- 
+
  4. Create your playbook. Use one of the examples from the examples directory to construct a playbook using the JFrog Ansible roles. These roles will be applied to your inventory and provision software.
- 
+
  5. Then execute with the following command to provision the JFrog Platform with Ansible.
- 
-```
+
+```bash
 ansible-playbook -vv platform.yml -i hosts.ini"
 ```
 
@@ -51,7 +51,7 @@ ansible-playbook -vv platform.yml -i hosts.ini"
 For production deployments,You may want to generate your master and join keys and apply it to all the nodes.
 **IMPORTANT** : Save below generated master and join keys for future upgrades
 
-```
+```bash
 MASTER_KEY_VALUE=$(openssl rand -hex 32)
 JOIN_KEY_VALUE=$(openssl rand -hex 32)
 ansible-playbook -vv platform.yml -i hosts.ini --extra-vars "master_key=$MASTER_KEY_VALUE join_key=$JOIN_KEY_VALUE"
@@ -60,13 +60,21 @@ ansible-playbook -vv platform.yml -i hosts.ini --extra-vars "master_key=$MASTER_
 ## Using [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html) to Encrypt Vars
 Some vars you may want to keep secret. You may put these vars into a separate file and encrypt them using [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html).
 
+For example, you will probably change the default password for the admin user
+
+```yaml
+# Default password
+artifactory_admin_password: password
 ```
+
+
+```bash
 ansible-vault encrypt secret-vars.yml --vault-password-file ~/.vault_pass.txt
 ```
 
 then in your playbook include the secret vars file.
 
-```
+```yaml
 - hosts: artifactory_servers
   collections:
     - community.general
@@ -81,7 +89,7 @@ then in your playbook include the secret vars file.
 ## Upgrades
 All JFrog product roles support software updates. To use a role to perform a software update only, use the _<product>_upgrade_only_ variable and specify the version. See the following example.
 
-```
+```yaml
 - hosts: artifactory_servers
   collections:
     - community.general
@@ -108,7 +116,7 @@ Create an external database as documented [here](https://www.jfrog.com/confluenc
 
 For example, for artifactory, these below values needs to be set for using external postgresql
 
-```
+```yaml
 postgres_enabled: false
 
 artifactory_db_type: postgresql
@@ -124,11 +132,11 @@ artifactory_db_url: jdbc:postgresql://<external_db_host_ip>:5432/{{ artifactory_
 1. Go to the ansible_collections/jfrog/platform directory.
 2. Update the galaxy.yml meta file as needed. Update the version.
 3. Build the archive. (Requires Ansible 2.9+)
-```
+```bash
 ansible-galaxy collection build
 ```
 
-## OS support 
+## OS support
 The JFrog Platform Ansible Collection can be installed on the following operating systems:
 
 * Ubuntu LTS versions (18.04/20.4/22.04)
@@ -139,6 +147,6 @@ The JFrog Platform Ansible Collection can be installed on the following operatin
 ## Known issues
 * Refer [here](https://github.com/jfrog/JFrog-Cloud-Installers/issues?q=is%3Aopen+is%3Aissue+label%3AAnsible)
 * By default, ansible_python_interpreter: "/usr/bin/python3" used , For Centos/RHEL-7, Set this to "/usr/bin/python" . For example
-```
+```bash
 ansible-playbook -vv platform.yml -i hosts.ini -e 'ansible_python_interpreter=/usr/bin/python'
 ```

--- a/Ansible/ansible_collections/jfrog/platform/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/README.md
@@ -60,7 +60,7 @@ ansible-playbook -vv platform.yml -i hosts.ini --extra-vars "master_key=$MASTER_
 ## Using [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html) to Encrypt Vars
 Some vars you may want to keep secret. You may put these vars into a separate file and encrypt them using [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html).
 
-For example, you will probably change the default password for the admin user
+For example, you will probably change the default password for the admin user using an encrypted file.
 
 ```yaml
 # Default password

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/defaults/main.yml
@@ -64,10 +64,9 @@ artifactory_gid: 1030
 # If this is an upgrade
 artifactory_upgrade_only: false
 
-# Default username and password
-artifactory_admin_username: admin
-artifactory_admin_password: password
-
+# Default username and password, uncomment and change to manage with ansible
+# artifactory_admin_username: admin
+# artifactory_admin_password: password
 artifactory_service_file: /lib/systemd/system/artifactory.service
 
 # Provide systemyaml content below with 2-space indentation

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -110,7 +110,7 @@
     group: "{{ artifactory_group }}"
   loop:
     - "{{ artifactory_home }}/var/data"
-    - "{{ artifactory_home }}/var/etc/access/"
+    - "{{ artifactory_home }}/var/etc/"
     - "{{ artifactory_home }}/var/etc/security/"
     - "{{ artifactory_home }}/var/etc/artifactory/info/"
 

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -175,6 +175,9 @@
     owner: "{{ artifactory_user }}"
     group: "{{ artifactory_group }}"
     mode: 0600
+  when: 
+    - artifactory_admin_username is defined
+    - artifactory_admin_password is defined
   notify: Restart artifactory
 
 - name: Check if included database driver is the correct version

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -110,7 +110,7 @@
     group: "{{ artifactory_group }}"
   loop:
     - "{{ artifactory_home }}/var/data"
-    - "{{ artifactory_home }}/var/etc"
+    - "{{ artifactory_home }}/var/etc/access/"
     - "{{ artifactory_home }}/var/etc/security/"
     - "{{ artifactory_home }}/var/etc/artifactory/info/"
 
@@ -166,6 +166,15 @@
   when:
     - artifactory_licenses is defined
     - artifactory_licenses | length > 0
+  notify: Restart artifactory
+
+- name: Set up Artifactory admin account 
+  ansible.builtin.template:
+    src: bootstrap.creds
+    dest: "{{ artifactory_home }}/var/etc/access/"
+    owner: "{{ artifactory_user }}"
+    group: "{{ artifactory_group }}"
+    mode: 0600
   notify: Restart artifactory
 
 - name: Check if included database driver is the correct version

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/templates/bootstrap.creds.j2
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/templates/bootstrap.creds.j2
@@ -1,0 +1,2 @@
+{{ artifactory_admin_username }}@*={{ artifactory_admin_password }}
+


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [X] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
This PR creates the initial admin password with the chosen string. It suggests using ansible-vault to encrypt it.
We need it because software deployed with default passwords is a bad practice.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
#294 

**Special notes for your reviewer**:
Credits to @eugene-krivosheyev for the initial solution.
