### PR TITLE
[ansible/artifactory] Assert that database username and password are defined.

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/postgres/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/postgres/tasks/install.yml
@@ -1,3 +1,13 @@
+- name: Assert database username and password are defined
+  ansible.builtin.assert:
+    that:
+      - curr_user.username is defined
+      - curr_user.password is defined
+  loop: "{{ database | dict2items | map(attribute='value') | list }}"
+  loop_control:
+    loop_var: curr_user
+  when: curr_user.enabled | bool
+
 - name: Define OS-specific variables
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
 
@@ -80,16 +90,6 @@
     port: "{{ postgres_port }}"
     timeout: 120
     sleep: 10
-
-- name: Assert database username and password are defined
-  ansible.builtin.assert:
-    that:
-      - curr_user.username is defined
-      - curr_user.password is defined
-  loop: "{{ database | dict2items | map(attribute='value') | list }}"
-  loop_control:
-    loop_var: curr_user
-  when: curr_user.enabled | bool
 
 - name: Create user
   become: true

--- a/Ansible/ansible_collections/jfrog/platform/roles/postgres/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/postgres/tasks/install.yml
@@ -81,6 +81,16 @@
     timeout: 120
     sleep: 10
 
+- name: Assert database username and password are defined
+  ansible.builtin.assert:
+    that:
+      - curr_user.username is defined
+      - curr_user.password is defined
+  loop: "{{ database | dict2items | map(attribute='value') | list }}"
+  loop_control:
+    loop_var: curr_user
+  when: curr_user.enabled | bool
+
 - name: Create user
   become: true
   become_user: postgres


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
The looping in the creation tasks for user, database and privileges in the postgres role did not fail on undefined values. Input validation was missing, and the logging of item=None is not so useful.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #311 


**Special notes for your reviewer**:

