### PR TITLE
[ansible/artifactory] IPv6 in README.md

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/README.md
@@ -150,3 +150,20 @@ The JFrog Platform Ansible Collection can be installed on the following operatin
 ```bash
 ansible-playbook -vv platform.yml -i hosts.ini -e 'ansible_python_interpreter=/usr/bin/python'
 ```
+
+* How to avoid IPv6 binding
+
+Some distributions have two entries for localhost in `/etc/hosts`:
+
+```
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+```
+
+This can cause Java apps trying binding using IPv6, which fails when that's disabled. This causes some tcp ports not listening, like the Artifactory router service.
+
+Solution: add an extra JAVA_OPTION: `-Djava.net.preferIPv4Stack=true` to this variable:
+
+```
+artifactory_extra_java_opts: '-server -Xms512m -Xmx4g -Xss256k -XX:+UseG1GC -Djava.net.preferIPv4Stack=true'
+```


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Sometimes Artifactory launches, but port 8082 or 8081 is not listening on IPv4.
This addistion to the README.md explains how to deal with IPv6 binding issue.

**Which issue this PR fixes** 
fixes #347


**Special notes for your reviewer**:

