### PR TITLE
[ansible/platform] Fixes #331 Install doesn't work with non-default artifactory_user and artifactory_group

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/shared/install_service.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/shared/install_service.yml
@@ -1,5 +1,5 @@
 ---
 - name: Create artifactory service
   become: true
-  ansible.builtin.command: "{{ artifactory_home }}/app/bin/installService.sh"
+  ansible.builtin.command: "{{ artifactory_home }}/app/bin/installService.sh {{ artifactory_user }} {{ artifactory_group }}"
   notify: Restart artifactory

--- a/Ansible/ansible_collections/jfrog/platform/roles/distribution/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/distribution/defaults/main.yml
@@ -24,7 +24,7 @@ distribution_home: "{{ jfrog_home_directory }}/distribution"
 
 distribution_install_script_path: "{{ distribution_home }}/app/bin"
 distribution_thirdparty_path: "{{ distribution_home }}/app/third-party"
-distribution_archive_service_cmd: "{{ distribution_install_script_path }}/installService.sh"
+distribution_archive_service_cmd: "{{ distribution_install_script_path }}/installService.sh --user {{ distribution_user }} --group {{ distribution_group }}"
 distribution_service_file: /lib/systemd/system/distribution.service
 
 # distribution users and groups

--- a/Ansible/ansible_collections/jfrog/platform/roles/insight/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/insight/defaults/main.yml
@@ -24,7 +24,7 @@ insight_home: "{{ jfrog_home_directory }}/insight"
 
 insight_install_script_path: "{{ insight_home }}/app/bin"
 insight_thirdparty_path: "{{ insight_home }}/app/third-party"
-insight_archive_service_cmd: "{{ insight_install_script_path }}/installService.sh"
+insight_archive_service_cmd: "{{ insight_install_script_path }}/installService.sh --user {{ insight_user }} --group {{ insight_group }}"
 insight_service_file: /lib/systemd/system/insight.service
 
 # Insight users and groups

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/defaults/main.yml
@@ -24,7 +24,7 @@ xray_home: "{{ jfrog_home_directory }}/xray"
 
 xray_install_script_path: "{{ xray_home }}/app/bin"
 xray_thirdparty_path: "{{ xray_home }}/app/third-party"
-xray_archive_service_cmd: "{{ xray_install_script_path }}/installService.sh"
+xray_archive_service_cmd: "{{ xray_install_script_path }}/installService.sh --user {{ xray_user }} --group {{ xray_group }}"
 xray_service_file: /lib/systemd/system/xray.service
 
 # Xray users and groups


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

### What this PR does / why we need it:
Artifactory, and probably all services, will fail to start when using a non-default value for $service_user and $service_group

### Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #331 
GitHub https://github.com/jfrog/JFrog-Cloud-Installers/issues/331

### Special notes for your reviewer:
This is a signed/signed-off copy of https://github.com/jfrog/JFrog-Cloud-Installers/pull/332 by [@Hiruma31](https://github.com/Hiruma31)

I only worked on the Artifactory part, but included the other components based on the documentation (they apparently don't use positional arguments like Artifactory's installer)
[XRay](https://jfrog.com/help/r/jfrog-installation-setup-documentation/install-xray-single-node-with-linux-archive)
[Insight](https://jfrog.com/help/r/jfrog-installation-setup-documentation/insight-single-node-linux-archive-installation)
[Distribution](https://jfrog.com/help/r/jfrog-installation-setup-documentation/mission-control-and-distribution-custom-volumes)
