### PR TITLE
[ansible/artifactory] Support RHEL 9 in rabbitmq setup

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/rabbitmq/setup/RedHat.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/rabbitmq/setup/RedHat.yml
@@ -5,6 +5,8 @@
             el7
         {%- elif linux_distro in ['centos8','redhat8'] -%}
             el8
+        {%- elif linux_distro in ['centos9','redhat9'] -%}
+            el9
         {%- endif -%}
 
 - name: Find socat package

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/rabbitmq/upgrade/RedHat.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/rabbitmq/upgrade/RedHat.yml
@@ -5,6 +5,8 @@
             el7
         {%- elif linux_distro in ['centos8','redhat8'] -%}
             el8
+        {%- elif linux_distro in ['centos9','redhat9'] -%}
+            el9
         {%- endif -%}
 
 - name: Find erlang package


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:

This adds support for EL9 distros (e.g. RHEL 9 and CentOS 9). Without this fix, Xray installation fails on EL 9 distributions because it attempts to install incompatible RPM packages for _socat_ and _erlang_.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

