### PR TITLE
[ansible/artifactory] Bugfix when enabling artifactory_docker_registry_subdomain 

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/templates/artifactory.conf.j2
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx_ssl/templates/artifactory.conf.j2
@@ -18,7 +18,11 @@
   ## server configuration
   server {
   listen 443 ssl http2;
+{% if artifactory_docker_registry_subdomain %}
+  server_name ~(?<repo>.+)\.{{ server_name }};
+{% else %}
   server_name {{ server_name }};
+{% endif %}
   if ($http_x_forwarded_proto = '') {
   set $http_x_forwarded_proto  $scheme;
   }


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Amends `server_name` to create a `repo` variable in Nginx config. That is needed for the rewrite rule when artifactory_docker_registry_subdomain is true.
```  
 {% if artifactory_docker_registry_subdomain %}rewrite ^/(v1|v2)/(.*) /artifactory/api/docker/$repo/$1/$2;{% endif %}
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #353


**Special notes for your reviewer**:

