### PR TITLE
[ansible/artifactory] Fix for #361 postgres_rpmkey_url

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
+++ b/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Platform Ansible Collection Changelog
 All changes to this collection will be documented in this file.
 
+## [10.16.5] - Jan 01, 2024
+* Postgres - change to the new location of the RPM GPG key URL.
+
 ## [10.16.4] - Dec 21, 2023
 * Artifactory - Upgrade version when tar is already present [GH-356](https://github.com/jfrog/JFrog-Cloud-Installers/pull/356)
 * Product Updates/fixes

--- a/Ansible/ansible_collections/jfrog/platform/roles/postgres/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/roles/postgres/README.md
@@ -14,6 +14,11 @@ postgres_allowed_hosts:
 
 **Update this variable to only allow access from Artifactory, Distribution, Insight and Xray.**
 
+
+Since 2024-01-03 the GPG key has a new location.
+```
+postgres_rpmkey_url: "https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL"
+```
 ## Example Playbook
 ```
 ---

--- a/Ansible/ansible_collections/jfrog/platform/roles/postgres/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/postgres/defaults/main.yml
@@ -7,6 +7,9 @@ postgres_listen_addresses: 0.0.0.0
 # Default port of Postgres server
 postgres_port: 5432
 
+# Location of GPG key used to sign the RPMs
+postgres_rpmkey_url: "https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL"
+
 # Server version in package:
 postgres_server_pkg_version: "{{ postgres_version | replace('.', '') }}"
 

--- a/Ansible/ansible_collections/jfrog/platform/roles/postgres/tasks/RedHat.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/postgres/tasks/RedHat.yml
@@ -37,7 +37,7 @@
 - name: Import PostgreSQL GPG public key
   become: true
   ansible.builtin.rpm_key:
-    key: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    key: "{{ postgres_rpmkey_url }}"
     state: present
   register: download_postgresql_key
   until: download_postgresql_key is success


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [X] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Fixes the URL of the Postgresql RPM GPG key to the new location, using a default variable. 

Install with included postgres role is broken since yesterday.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #361 


**Special notes for your reviewer**:

