### PR TITLE
[ansible/artifactory] Use `fetch` and `lookup('ini')` to get the version

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/upgrade.yml
@@ -57,15 +57,15 @@
     state: directory
 
 - name: Check artifactory version
-  ansible.builtin.shell: |
-    set -o pipefail;
-    grep artifactory.product.version "{{ artifactory_home }}/app/artifactory.product.version.properties" |cut -d= -f2
-  register: check_version_cmd
+  ansible.builtin.fetch:
+    src: "{{ artifactory_home }}/app/artifactory.product.version.properties"
+    dest: "/tmp/artifactory.product.version.properties"
+    flat: true
   changed_when: false
 
 - name: Set running_version
   ansible.builtin.set_fact:
-    running_version: "{{ check_version_cmd.stdout }}"
+    running_version: "{{ lookup('ansible.builtin.ini', 'artifactory.product.version', type='properties', file='/tmp/artifactory.product.version.properties') }}"
 
 - name: Delete artifactory app directory
   become: true


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:

Changes the way that the Artifactory product version is obtained.

**Which issue this PR fixes**: fixes #365

**Special notes for your reviewer**:

`ansible.builtin.slurp` could also be used if we want to not rely on a temporary file, but it requires some filtering within Ansible to the same data.

