### PR TITLE
[ansible/artifactory] Added `no_log` to postgres username password assertion

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/postgres/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/postgres/tasks/install.yml
@@ -7,6 +7,7 @@
   loop_control:
     loop_var: curr_user
   when: curr_user.enabled | bool
+  no_log: true  # secret passwords
 
 - name: Define OS-specific variables
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Currently, the Postgres username and password are being displayed in plain text as part of the assertion task. Thus, rendering the no_log in [these](https://github.com/jfrog/JFrog-Cloud-Installers/blob/master/Ansible/ansible_collections/jfrog/platform/roles/postgres/tasks/install.yml#L94-L136) subsequent tasks useless. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

