### PR TITLE
[ansible/postgres] Fix for auth method in pg_hba.conf file 

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/postgres/templates/pg_hba.conf.j2
+++ b/Ansible/ansible_collections/jfrog/platform/roles/postgres/templates/pg_hba.conf.j2
@@ -13,6 +13,6 @@ host    all             all             ::1/128                 md5
 ## remote connections IPv4
 {% if postgres_allowed_hosts and postgres_allowed_hosts is iterable -%}
 {%- for host in postgres_allowed_hosts %}
-{{ host.type | default('host') }}         {{ host.database | default('all') }}        {{ host.user | default('all') }}             {{ host.address | default('0.0.0.0/0') }}            {{ item.auth | default('trust') }}
+{{ host.type | default('host') }}         {{ host.database | default('all') }}        {{ host.user | default('all') }}             {{ host.address | default('0.0.0.0/0') }}            {{ host.method | default('trust') }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [X] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR allows controlling the auth method for remote database clients. If `postgres_listen_addresses` variable is not change, the installed postgres will listen on all interfaces. This allows a more secure setup of the auth method, from 'trust' to 'password' for instance.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Support case 326048

**Special notes for your reviewer**:
SECURITY PATCH
