### PR TITLE
[ansible/artifactory] Fix indentation in nginx conf

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/templates/artifactory.conf.j2
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/templates/artifactory.conf.j2
@@ -2,66 +2,69 @@
 ## this configuration was generated for JFrog Artifactory ##
 ###########################################################
 
-  ## add HA entries when ha is configure
-  upstream artifactory {
-  server 127.0.0.1:8082;
+## add HA entries when ha is configure
+upstream artifactory {
+    server 127.0.0.1:8082;
 }
-  upstream artifactory-direct {
-  server 127.0.0.1:8081;
+upstream artifactory-direct {
+    server 127.0.0.1:8081;
 }
 {% if artifactory_nginx_ssl_enabled is defined and artifactory_nginx_ssl_enabled %}
-  ssl_protocols TLSv1.2 TLSv1.3;
-  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-  ssl_certificate      {{ ssl_certificate_path }}/{{ ssl_certificate_name }};
-  ssl_certificate_key  {{ ssl_certificate_key_path }}/{{ ssl_certificate_key_name }};
-  ssl_session_cache shared:SSL:1m;
-  ssl_prefer_server_ciphers   on;
-  {% endif %}
-  ## server configuration
-  server {
- {% if artifactory_nginx_ssl_enabled is defined and artifactory_nginx_ssl_enabled %}
-  listen 443 ssl http2;
+## add ssl entries when https has been set in config
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+ssl_certificate      {{ ssl_certificate_path }}/{{ ssl_certificate_name }};
+ssl_certificate_key  {{ ssl_certificate_key_path }}/{{ ssl_certificate_key_name }};
+ssl_session_cache shared:SSL:1m;
+ssl_prefer_server_ciphers   on;
+{% endif %}
+## server configuration
+server {
+{% if artifactory_nginx_ssl_enabled is defined and artifactory_nginx_ssl_enabled %}
+    listen 443 ssl http2;
 {% else %}
-  listen 80;
+    listen 80;
 {% endif %}
 {% if artifactory_docker_registry_subdomain %}
-  server_name ~(?<repo>.+)\.{{ server_name }};
+    server_name ~(?<repo>.+)\.{{ server_name }};
 {% else %}
-  server_name {{ server_name }};
+    server_name {{ server_name }};
 {% endif %}
-  if ($http_x_forwarded_proto = '') {
-  set $http_x_forwarded_proto  $scheme;
-  }
-  ##Set up mTLS Verification and Certificate Termination on the Reverse Proxy
-  {% if mtls_ca_certificate_install %}
-  ssl_verify_client      on;
-  ssl_verify_depth       2;
-  ssl_client_certificate {{ mtls_ca_certificate_path }}/{{ mtls_mtls_ca_certificate_crt_name }};
-  proxy_set_header X-JFrog-Client-Cert $ssl_client_escaped_cert;
-  {% endif %}
-  ## Application specific logs
-  access_log /var/log/nginx/artifactory-access.log;
-  error_log /var/log/nginx/artifactory-error.log;
-  rewrite ^/$ /ui/ redirect;
-  rewrite ^/ui$ /ui/ redirect;
-  {% if artifactory_docker_registry_subdomain %}rewrite ^/(v1|v2)/(.*) /artifactory/api/docker/$repo/$1/$2;{% endif %}
-  chunked_transfer_encoding on;
-  client_max_body_size 0;
-  location / {
-  proxy_read_timeout  2400s;
-  proxy_pass_header   Server;
-  proxy_cookie_path   ~*^/.* /;
-  proxy_pass          "http://artifactory";
-  proxy_next_upstream error timeout non_idempotent;
-  proxy_next_upstream_tries    1;
-  proxy_set_header    X-JFrog-Override-Base-Url $http_x_forwarded_proto://$host:$server_port;
-  proxy_set_header    X-Forwarded-Port  $server_port;
-  proxy_set_header    X-Forwarded-Proto $http_x_forwarded_proto;
-  proxy_set_header    Host              $http_host;
-  proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
-
-  location ~ ^/artifactory/ {
-    proxy_pass    http://artifactory-direct;
+    if ($http_x_forwarded_proto = '') {
+      set $http_x_forwarded_proto  $scheme;
     }
-  }
+{% if mtls_ca_certificate_install %}
+    ## Set up mTLS Verification and Certificate Termination on the Reverse Proxy
+    ssl_verify_client      on;
+    ssl_verify_depth       2;
+    ssl_client_certificate {{ mtls_ca_certificate_path }}/{{ mtls_mtls_ca_certificate_crt_name }};
+    proxy_set_header X-JFrog-Client-Cert $ssl_client_escaped_cert;
+{% endif %}
+    ## Application specific logs
+    access_log /var/log/nginx/artifactory-access.log;
+    error_log /var/log/nginx/artifactory-error.log;
+    rewrite ^/$ /ui/ redirect;
+    rewrite ^/ui$ /ui/ redirect;
+{% if artifactory_docker_registry_subdomain %}
+    rewrite ^/(v1|v2)/(.*) /artifactory/api/docker/$repo/$1/$2;
+{% endif %}
+    chunked_transfer_encoding on;
+    client_max_body_size 0;
+    location / {
+      proxy_read_timeout  2400s;
+      proxy_pass_header   Server;
+      proxy_cookie_path   ~*^/.* /;
+      proxy_pass          "http://artifactory";
+      proxy_next_upstream error timeout non_idempotent;
+      proxy_next_upstream_tries    1;
+      proxy_set_header    X-JFrog-Override-Base-Url $http_x_forwarded_proto://$host:$server_port;
+      proxy_set_header    X-Forwarded-Port  $server_port;
+      proxy_set_header    X-Forwarded-Proto $http_x_forwarded_proto;
+      proxy_set_header    Host              $http_host;
+      proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+      location ~ ^/artifactory/ {
+        proxy_pass    http://artifactory-direct;
+      }
+    }
 }


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR fixes broken indentation and adjusts it to 4 spaces to ensure consistency with the nginx config generator inside Artifactory.
It makes it easier to do modifications to artifactory.conf going forward.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
Does not fix any reported issue.

**Special notes for your reviewer**:
If artifactory_docker_registry_subdomain=true, the "chunked_transfer_encoding on;" line was placed on the same line as the rewrite rule, this PR fixes this along with other cosmetic changes.

It's possible to test these changes by installing the modified collection and running the playbook. The collection can be installed with the following command: 
```
ansible-galaxy collection install git+https://github.com/PolaricEntropy/JFrog-Cloud-Installers.git#/Ansible/ansible_collections/jfrog/platform/,fix-nginx-conf-indentation
``` 
