### PR TITLE
[dell-blueprints] Add JFrog Dell TOSCA blueprints

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Submitting contributions or comments that you know to violate the intellectual property or privacy rights of others
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer. Complaints will result in a response and be reviewed and investigated in a way that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/.github/workflows/dell-release.yaml
+++ b/.github/workflows/dell-release.yaml
@@ -1,0 +1,40 @@
+name: Release JFrog Dell Blueprint
+
+on:
+  push:
+    tags:
+      - "jfrog-dell-blueprints/v*"
+  workflow_dispatch:
+    inputs:
+      chart_version:
+        description: "Helm chart version for sizing templates (default: latest)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#jfrog-dell-blueprints/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build zip artifact
+        working-directory: JFrog-dell-blueprints
+        run: |
+          make all \
+            VERSION="${{ steps.version.outputs.version }}" \
+            CHART_VERSION="${{ inputs.chart_version }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "v${{ steps.version.outputs.version }}"
+          generate_release_notes: true
+          files: "JFrog-dell-blueprints/target/jfrog-dell-${{ steps.version.outputs.version }}.zip"

--- a/.github/workflows/dell-validate-blueprints.yaml
+++ b/.github/workflows/dell-validate-blueprints.yaml
@@ -1,0 +1,35 @@
+name: Validate Dell Blueprints
+
+on:
+  pull_request:
+    paths:
+      - "JFrog-dell-blueprints/**/blueprint.yaml"
+      - "JFrog-dell-blueprints/**/CHANGELOG.yaml"
+      - "JFrog-dell-blueprints/scripts/validate_blueprints.sh"
+      - ".github/workflows/dell-validate-blueprints.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install validator dependency
+        run: python -m pip install --upgrade pip pyyaml
+
+      - name: Run blueprint validation
+        working-directory: JFrog-dell-blueprints
+        run: |
+          chmod +x scripts/validate_blueprints.sh
+          ./scripts/validate_blueprints.sh

--- a/JFrog-dell-blueprints/.cursor/rules/dell-blueprint-assist.mdc
+++ b/JFrog-dell-blueprints/.cursor/rules/dell-blueprint-assist.mdc
@@ -1,0 +1,501 @@
+---
+description: >
+  Dell Blueprint Assist — invoke this skill to validate, audit, and fix Dell TOSCA blueprints.
+  Use when: validating blueprint.yaml, checking CHANGELOG.yaml, reviewing inputs/outputs,
+  auditing constraints, running pre-commit checks, or asking "is this blueprint correct?".
+globs:
+  - "**/blueprint.yaml"
+  - "**/CHANGELOG.yaml"
+alwaysApply: false
+---
+
+# Dell Blueprint Assist — Validation Skill
+
+When invoked, run **all sections in order** against the target blueprint file(s).
+Report each finding as: `[PASS]`, `[FAIL]`, or `[WARN]`, grouped by section.
+After all checks, output a **Summary** block and a **Recommended Fixes** list.
+
+---
+
+## Section 1 — YAML Integrity
+
+1. Confirm the file starts with a copyright/license comment block before the first `---`.
+2. Confirm the file parses as valid YAML with no syntax errors (duplicate keys, bad indentation, bare colons in values, tabs used as indentation).
+3. Confirm `tosca_definitions_version: dell_1_1` is the first non-comment key.
+4. Confirm `description` is present and is a non-empty string.
+
+---
+
+## Section 2 — Imports
+
+1. `imports` must be a list.
+2. `dell/types/types.yaml` must be present.
+3. Plugin references must use the version range format:
+   ```
+   plugin:<plugin-name>?version= >=X.Y.Z.W,<A.0.0.0
+   ```
+4. No import should be duplicated.
+5. Local file imports (`top_level/*.yaml`, `application/*.yaml`) are expected for modular blueprints — do not flag.
+6. Flag any import that is not `dell/types/types.yaml`, a `plugin:` URI, or a local relative path as `[WARN]`.
+
+---
+
+## Section 3 — Inputs
+
+For **each** key under `inputs`:
+
+| Check | Rule |
+|---|---|
+| Required fields | `type`, `hidden`, `allow_update`, `required`, `display_label`, `description` all present |
+| Name casing | snake_case only (`^[a-z][a-z0-9_]*$`) |
+| Constraint present | At least one of `pattern`, `valid_values`, or `type`-level constraint — **except** `dict` and `list` types which are exempt |
+| error_message | Must accompany every `pattern` or `valid_values` constraint |
+| valid_values content | Must contain **raw values only** — never descriptive text (e.g., `- xsmall` not `- xsmall - 1 replica, 1 CPU / 4 Gi`) |
+| Secrets | `type: secret_key` required for DAP credential/kubeconfig inputs |
+| License secret | License input should be `type: secret_key` with `type: general` constraint (DAP general secret containing raw license text) |
+| Helm boolean values | `[FAIL]` if `type: boolean` is used for any value that flows into Helm `set_values`. Use `type: string` with `valid_values: ["true", "false"]` |
+| Scalable instances | `[FAIL]` if `type: boolean` is used for `default_instances`. Use `type: integer` with `valid_values: [0, 1]` |
+| Semver inputs | chart version inputs must use pattern `^\d+\.\d+\.\d+$` |
+| Namespace inputs | must use pattern `^[a-z0-9][a-z0-9\-]{0,62}$` |
+| K8s name inputs | must use pattern `^[a-z0-9][a-z0-9\-]*$` |
+| K8s secret name | must use pattern `^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$` |
+| DNS hostname inputs | must use pattern `^$\|^[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)+$` (allow empty, DNS only, no IPs) |
+| Secret data key | must use pattern `^[a-zA-Z0-9._\-]+$` |
+| Embedded secrets | `[FAIL]` if `default` contains passwords, tokens, or key material |
+| Conditional visibility | Inputs with `only_with` must reference a valid parent input and value |
+| Dual `only_with` | Inputs with multiple `only_with` keys must reference valid ancestors at each level |
+| String boolean `only_with` | When referencing string-type boolean inputs in `only_with`, use string value (`"false"` not `false`) |
+| Copyright header | File must start with copyright/license comment block before `---` |
+
+---
+
+## Section 4 — Input Groups
+
+1. Every input name listed in `inputs` must appear in exactly one group under `input_groups`.
+2. No input may appear in more than one group.
+3. Groups must include `display_label`, `collapsible`, `index`, and `inputs`.
+4. Each group's `inputs` list must only reference inputs defined in Section 3.
+5. Recommended group order (warn if violated):
+   - credentials → infrastructure → persistence → database → chart_settings → licensing → networking
+6. Group `index` values must be contiguous integers starting from 0.
+7. Each input's `display.index` must be contiguous within its group starting from 0.
+
+---
+
+## Section 5 — DSL Definitions
+
+1. Anchors (`&name`) must be referenced (`*name`) at least once; flag unused anchors as `[WARN]`.
+2. Anchor names must be snake_case.
+3. All Helm repo configs inside anchors must include `name` and `repo_url`.
+
+---
+
+## Section 6 — Node Templates
+
+### Helm Node Chain
+
+For Helm-based blueprints, verify the presence and relationship chain:
+
+```
+dell.nodes.helm.Binary
+  └── dell.nodes.helm.Repo  (relationships: run_on_host → Binary)
+       └── dell.nodes.helm.Release  (relationships: run_on_host → Binary, depends_on → Repo)
+```
+
+- `[FAIL]` if any link in the chain is missing.
+- `[FAIL]` if `dell.nodes.helm.Release` does not have both `run_on_host` and `depends_on`.
+
+### Multi-Release Ordering
+
+When a blueprint includes multiple `dell.nodes.helm.Release` nodes:
+
+- The primary release must `depends_on` any prerequisite releases (e.g., ingress controller).
+- Optional releases must use `capabilities.scalable.default_instances` tied to an **integer** `get_input` (not boolean) to conditionally deploy (0 when disabled, 1 when enabled).
+- `[FAIL]` if a prerequisite release is present but the primary release does not `depends_on` it.
+- `[FAIL]` if `default_instances` references a `type: boolean` input (DAP cannot convert boolean to integer).
+
+### ServiceComponent Composition (k8s_stack)
+
+For blueprints using `dell.nodes.ServiceComponent`:
+
+- Each component must have `blueprint.id`, `external_resource: true`, and `revision_id`.
+- `deployment.display_name` should use `concat` with `get_sys: [deployment, name]`.
+- `depends_on` must correctly chain components (e.g., k8s → cert_manager → gpu_operator).
+- Conditional components use `scalable.default_instances` with integer input.
+- `[FAIL]` if `external_resource: true` is missing on any `ServiceComponent`.
+
+### Release Properties
+
+For every `dell.nodes.helm.Release` node:
+
+| Check | Rule |
+|---|---|
+| `client_config` | Must use `get_secret` → `get_input` pattern (never hardcoded) |
+| `resource_config.name` | Must be `get_input` |
+| `resource_config.chart` | Must be `<repo>/<chart-name>` string |
+| `resource_config.flags` | Must include `namespace` and `create-namespace` |
+| `resource_config.flags` | Should include `atomic`, `wait`, and `timeout` for production blueprints |
+| `resource_config.flags.version` | Must be `get_input` — never a hardcoded version string |
+| `resource_config.flags` | `[FAIL]` if `--values` flag references a file path (DAP cannot resolve it — use `values_file` or build-time merge) |
+| Hardcoded values in `set_values` | Flag any `get_input`-eligible value that is hardcoded as `[WARN]` |
+| Dict in `set_values` | `[FAIL]` if any `set_values` entry uses dict-lookup `get_input` pattern (causes `unhashable type: 'dict'` in Helm plugin) |
+| Boolean in `set_values` | `[FAIL]` if any `set_values` value references a `type: boolean` input (DAP passes Python `True`/`False`) |
+
+### Kubernetes Resource Nodes
+
+For blueprints that create K8s resources before Helm install:
+
+- Namespace must use `dell.nodes.kubernetes.resources.Namespace` with `client_config: { get_secret: { get_input: k8s_credentials } }`.
+- Secrets must use `dell.nodes.kubernetes.resources.Secret` with `client_config` and proper `definition` (apiVersion, kind, metadata, type, stringData).
+- Secret nodes must `depends_on` the namespace node (`dell.relationships.depends_on`).
+- Helm release nodes must `depends_on` all secret nodes.
+- Conditional secret nodes must use `capabilities.scalable.default_instances` tied to a visible integer `get_input` (default `0`).
+- Both bundled and external DB credential nodes must `depends_on` the namespace node.
+- `[FAIL]` if a secret node does not depend on the namespace node.
+- `[FAIL]` if a Helm release does not depend on its prerequisite secret nodes.
+
+### License Configuration
+
+For JFrog Platform blueprints:
+
+- License must be stored in a K8s Secret (`jfrog-platform-license`) created via `dell.nodes.kubernetes.resources.Secret`.
+- The secret's `stringData` must pull from a DAP general secret: `get_secret: { get_input: license_secret_ref }`.
+- The `license_secret_ref` input must be `type: secret_key` with `type: general` constraint.
+- The Helm chart references the license via `artifactory.artifactory.license.secret` and `artifactory.artifactory.license.dataKey`.
+- The license secret node must use `capabilities.scalable.default_instances: { get_input: create_license_secret }` for optional deployment.
+- `[FAIL]` if license uses inline `licenseKey` in `set_values` (multi-line issues with `--set`).
+
+### Database Credentials Configuration
+
+For JFrog Platform blueprints with bundled/external database support:
+
+- Database credentials must be stored in a K8s Secret (`jfrog-platform-database-creds`) created via `dell.nodes.kubernetes.resources.Secret`.
+- Two mutually exclusive secret nodes are used: bundled (hardcoded defaults) and external (DAP secrets).
+- Both nodes are controlled by **visible** user-facing integer inputs (`create_bundled_db_secret`, `create_external_db_secret`), each defaulting to `0` and gated by `only_with` on `postgresql_enabled`.
+- Hidden integer toggles with `only_with` are **not reliable** for mutual exclusion (they do not resolve to `0` when the condition is unmet). Visible inputs avoid this problem.
+- Both nodes `depends_on` the namespace node (`create_namespace`).
+- The JDBC URL (`db-url`) must be constructed via `concat` to avoid Helm `--set` int64 port coercion.
+- The Helm chart references credentials via `database.secrets.*.name` and `database.secrets.*.key` in `set_values`.
+- `[FAIL]` if database credentials are passed directly via `set_values` instead of K8s secret references.
+- `[FAIL]` if JDBC URL is passed as a single string input through `--set` (causes `%!g(int64=...)` formatting).
+
+### Service Disablement
+
+For JFrog Platform blueprints:
+
+- Confirm these services are explicitly disabled unless the blueprint scope requires them:
+  - `xray.enabled: "false"`
+  - `distribution.enabled: "false"`
+  - `rabbitmq.enabled: "false"`
+- `[WARN]` if any of the above are missing from `set_values`.
+
+---
+
+## Section 7 — Capabilities (Outputs)
+
+1. At least one capability must be defined.
+2. Each capability must include `description` and `value`.
+3. `value` must use `get_input` or a `concat` expression — never a hardcoded string.
+4. Recommended capabilities for Helm blueprints: `release_name`, `namespace`, endpoint URL.
+5. Endpoint URL capabilities must use `concat` and include protocol prefix (`http://` or `https://`).
+
+---
+
+## Section 8 — Labels
+
+1. `labels` must be present with at least `csys-obj-type`.
+2. `blueprint_labels` must be present with `obj-type` and `csys-obj-type`.
+3. Recommended `csys-obj-type` value: `environment`.
+4. Recommended `obj-type` value for Helm blueprints: `helm`.
+
+---
+
+## Section 9 — CHANGELOG.yaml Validation
+
+1. `tosca_definitions_version: dell_1_1` must be the first key.
+2. `imports` must include `dell/types/types.yaml`.
+3. `labels` must include `csys-obj-type: environment`.
+4. `blueprint_labels` must include `obj-type` and `csys-obj-type`.
+5. The `dsl_definitions.changelog` map must be present.
+6. Each changelog entry must include: `ticket`, `developer`, `description`.
+7. All changelog keys must be valid semver strings (`^\d+\.\d+\.\d+$`).
+8. The highest semver key in `CHANGELOG.yaml` must match the intended release version.
+9. `[WARN]` if any described behavior change is not reflected by a changelog entry.
+
+---
+
+## Section 10 — Security Audit
+
+1. `[FAIL]` — any input `default` containing password/token/key/secret literal strings.
+2. `[FAIL]` — any `set_values` entry whose `value` is a literal credential.
+3. `[FAIL]` — `client_config` is not delegated to a secret input.
+4. `[WARN]` — `ingress_enabled` or `gateway_api_enabled` defaulting to `true` without a comment explaining the intent.
+5. `[WARN]` — External URLs in `repo_url` that are not `https://`.
+
+---
+
+## Section 11 — Build-Time Artifacts
+
+1. Generated files (networking config, sizing templates) must **not** be committed to source.
+2. The `build/` directory is gitignored and holds generated artifacts.
+3. `[FAIL]` if `blueprints/**/additional_resources/` or `blueprints/**/networking/` contains committed YAML files (these should be in `build/`).
+4. `[FAIL]` if any Helm release `flags` entry references a `--values` file path (DAP Helm plugin cannot resolve relative paths in flags — use `values_file` property or build-time merge into sizing templates).
+5. `[WARN]` if `scripts/sync_networking_modes.sh` writes to any path under `blueprints/` instead of `build/`.
+6. Verify that `scripts/merge_nginx_config.py` exists and is used by the Makefile to merge `nginx.mainConf` into sizing templates.
+7. Verify that `sync_networking_modes.sh` strips Go template whitespace trim modifiers (`{{-`/`-}}`) from the extracted nginx conf.
+
+---
+
+## Section 12 — DAP Platform Compatibility
+
+These checks catch known DAP/Cloudify platform issues that cause deployment failures:
+
+1. `[FAIL]` — `type: boolean` input referenced in `set_values` (DAP passes Python `True`/`False`, Helm expects `"true"`/`"false"`).
+2. `[FAIL]` — `type: boolean` input used for `capabilities.scalable.default_instances` (requires integer).
+3. `[FAIL]` — Dict-lookup pattern (`get_input: [dict_input, get_input: selector]`) used inside `set_values` (causes `unhashable type: 'dict'`).
+4. `[FAIL]` — `--values` flag in Helm release `flags` section referencing a relative file path (plugin only resolves `values_file`).
+5. `[FAIL]` — `type: secret_key` input used directly in `set_values` (resolves to `None` when hidden, causes `secret 'None' not found`). Use K8s Secret nodes instead.
+6. `[FAIL]` — Database credentials passed directly via `set_values` instead of K8s secret references (`database.secrets.*.name/key`).
+7. `[FAIL]` — JDBC URL passed as a single string through Helm `--set` (causes `%!g(int64=...)` port formatting). Use `concat` in a K8s Secret `stringData` field.
+8. `[FAIL]` — Hidden input used to control a Helm value that depends on a user-visible selector without `only_with` (DAP cannot derive input values).
+9. `[WARN]` — `only_with` referencing a boolean value without quotes when the input is `type: string` (use `"false"` not `false`).
+10. `[WARN]` — Hidden integer inputs with `only_with` used for mutual exclusion. DAP does not reliably resolve hidden integers to `0` when condition is unmet. Use visible user-controlled integer toggles instead.
+
+---
+
+## Output Format
+
+After all checks, produce:
+
+```
+## Validation Summary
+
+| Section | Status | Issues |
+|---|---|---|
+| YAML Integrity          | ✅ PASS / ❌ FAIL / ⚠️ WARN | <count> |
+| Imports                 | ... | ... |
+| Inputs                  | ... | ... |
+| Input Groups            | ... | ... |
+| DSL Definitions         | ... | ... |
+| Node Templates          | ... | ... |
+| Capabilities            | ... | ... |
+| Labels                  | ... | ... |
+| CHANGELOG.yaml          | ... | ... |
+| Security Audit          | ... | ... |
+| Build-Time Artifacts    | ... | ... |
+| DAP Compatibility       | ... | ... |
+
+**Overall: READY TO RELEASE / NEEDS FIXES / NEEDS REVIEW**
+```
+
+Then list all `[FAIL]` findings first, `[WARN]` findings second, each with:
+- Location (key path in file)
+- What rule was violated
+- Exact fix to apply
+
+---
+
+## Quick Fix Patterns
+
+Use these canonical snippets when generating fixes.
+
+### Missing constraint on string input
+```yaml
+constraints:
+  - pattern: '^[a-z0-9][a-z0-9\-]*$'
+    error_message: Must be a valid Kubernetes resource name.
+```
+
+### String boolean input (for Helm compatibility)
+```yaml
+type: string
+default: "true"
+constraints:
+  - valid_values:
+      - "true"
+      - "false"
+    error_message: Must be true or false.
+```
+
+### Integer toggle for conditional scaling
+```yaml
+type: integer
+default: 0
+constraints:
+  - valid_values: [0, 1]
+    error_message: Must be 0 (skip) or 1 (install).
+```
+
+### Chart version input
+```yaml
+type: string
+constraints:
+  - pattern: '^\d+\.\d+\.\d+$'
+    error_message: Must be a valid semantic version (e.g., 11.5.1).
+```
+
+### License secret input (DAP general secret)
+```yaml
+license_secret_ref:
+  type: secret_key
+  required: false
+  constraints:
+    - type: general
+      error_message: Secret must be of type general.
+```
+
+### Visible integer toggle for DB credentials (user-controlled)
+```yaml
+# In inputs.yaml — user sets to 1 for bundled DB
+create_bundled_db_secret:
+  type: integer
+  hidden: false
+  default: 0
+  only_with:
+    postgresql_enabled: "true"
+  constraints:
+    - valid_values: [0, 1]
+      error_message: Must be 0 (skip) or 1 (create).
+
+# In inputs.yaml — user sets to 1 for external DB
+create_external_db_secret:
+  type: integer
+  hidden: false
+  default: 0
+  only_with:
+    postgresql_enabled: "false"
+  constraints:
+    - valid_values: [0, 1]
+      error_message: Must be 0 (skip) or 1 (create).
+```
+
+### K8s Secret node with scalable toggle
+```yaml
+license_secret:
+  type: dell.nodes.kubernetes.resources.Secret
+  properties:
+    client_config: { get_secret: { get_input: k8s_credentials } }
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: jfrog-platform-license
+        namespace: { get_input: namespace }
+      type: Opaque
+      stringData:
+        artifactory.lic:
+          get_secret: { get_input: license_secret_ref }
+    options:
+      namespace: { get_input: namespace }
+  capabilities:
+    scalable:
+      properties:
+        default_instances: { get_input: create_license_secret }
+  relationships:
+    - target: create_namespace
+      type: dell.relationships.depends_on
+```
+
+### JDBC URL via concat (avoids Helm --set int64 coercion)
+```yaml
+db-url:
+  concat:
+    - "jdbc:postgresql://"
+    - { get_input: database_host }
+    - ":"
+    - { get_input: database_port }
+    - "/artifactory?sslmode="
+    - { get_input: database_ssl_mode }
+```
+
+### Helm Release client_config (never hardcode)
+```yaml
+client_config: { get_secret: { get_input: k8s_credentials } }
+```
+
+### Helm Release namespace flag
+```yaml
+flags:
+  - name: namespace
+    value: { get_input: namespace }
+  - name: create-namespace
+  - name: version
+    value: { get_input: chart_version }
+  - name: atomic
+  - name: wait
+  - name: timeout
+    value: "10m0s"
+```
+
+### License via K8s Secret reference in Helm
+```yaml
+- name: artifactory.artifactory.license.secret
+  value: jfrog-platform-license
+- name: artifactory.artifactory.license.dataKey
+  value: artifactory.lic
+```
+
+### Conditional input visibility (only_with)
+```yaml
+# Top-level selector reveals sub-inputs
+storage_class:
+  type: string
+  only_with:
+    persistence: storage_class
+
+# Nested: sub-selector reveals deeper inputs
+nfs_ip:
+  type: string
+  only_with:
+    persistence_type: nfs
+
+# Dual condition: both parent AND sub-selector must match
+filesystem_cache_enabled:
+  type: string
+  only_with:
+    persistence: storage_type
+    persistence_type: file-system
+
+# String boolean reference (not bare boolean)
+database_host:
+  type: string
+  only_with:
+    postgresql_enabled: "false"
+```
+
+### Simple string toggle for set_values (replaces dict-lookup)
+```yaml
+# Hidden input (not dict — avoids unhashable type error)
+nginx_enabled:
+  type: string
+  hidden: true
+  default: "true"
+  constraints:
+    - valid_values: ["true", "false"]
+      error_message: Must be true or false.
+
+# In set_values:
+- name: artifactory.nginx.enabled
+  value: { get_input: nginx_enabled }
+```
+
+### Conditional Helm release (scalable with integer)
+```yaml
+ingress_nginx_release:
+  type: dell.nodes.helm.Release
+  capabilities:
+    scalable:
+      properties:
+        default_instances: { get_input: install_ingress_controller }
+```
+
+### CHANGELOG entry
+```yaml
+dsl_definitions:
+  changelog:
+    1.0.1:
+      - ticket: JFROG-XXX
+        developer: <github-username>
+        description: >
+          <One sentence describing the user-facing change.>
+```

--- a/JFrog-dell-blueprints/.cursor/rules/dell-tosca-blueprint-standards.mdc
+++ b/JFrog-dell-blueprints/.cursor/rules/dell-tosca-blueprint-standards.mdc
@@ -1,0 +1,510 @@
+---
+description: Standards for developing Dell TOSCA blueprints in this repository
+globs:
+  - "**/blueprint.yaml"
+  - "**/CHANGELOG.yaml"
+alwaysApply: false
+---
+
+# Dell TOSCA Blueprint Development Standard
+
+Use this standard whenever creating or updating Dell blueprints in this repo.
+
+## Core Contract
+
+- Use `tosca_definitions_version: dell_1_1`.
+- Keep `imports` explicit and minimal.
+- Prefer official plugin version ranges (for example: `plugin:helm-plugin?version= >=1.4.0.0,<2.0.0.0`, `plugin:kubernetes-plugin?version= >=3.3.0.0,<4.0.0.0`).
+- Keep all YAML keys and list ordering stable unless there is a functional reason to change them.
+
+## Required File Structure
+
+For each blueprint directory, keep:
+
+- `blueprint.yaml`
+- `CHANGELOG.yaml`
+
+`CHANGELOG.yaml` must include a new semver section for every user-facing blueprint change.
+
+For larger blueprints, split into imported files (following k8s_stack pattern):
+
+```
+blueprint.yaml          # top-level imports, labels, blueprint_labels
+top_level/inputs.yaml   # user-visible inputs + input_groups
+top_level/inputs_hidden.yaml  # hidden/internal inputs
+top_level/outputs.yaml  # capabilities
+application/NN_component.yaml  # node_templates per component
+```
+
+For Helm-based blueprints with < ~20 inputs, a single `blueprint.yaml` is acceptable.
+
+## Copyright Headers
+
+Every YAML file must start with a copyright header:
+
+```yaml
+# Copyright (c) 2026 JFrog Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+---
+```
+
+## Input Design Rules
+
+For each input:
+
+- Include: `type`, `hidden`, `allow_update`, `required`, `display_label`, `description`.
+- Add validation constraints (`pattern`, `valid_values`, or `type`) with `error_message`.
+  - `dict` and `list` types are exempt from `pattern`/`valid_values` constraints.
+  - `valid_values` must contain **raw values only** — never descriptive text
+    (e.g., `- xsmall` not `- xsmall - 1 replica, 1 CPU / 4 Gi`).
+    Put descriptions in the `description` field instead.
+- Provide `default` only when a safe default is known.
+- Use snake_case names.
+- Keep descriptions operational and deployment-focused.
+- Use `only_with` to conditionally show inputs based on a parent toggle value.
+  - Scalar form: `only_with: { persistence: storage_class }`
+  - List form (match any): `only_with: { persistence: ['storage_class'] }`
+  - Dual (nested) form — both conditions must match:
+    ```yaml
+    only_with:
+      persistence: storage_type
+      persistence_type: file-system
+    ```
+  - Common patterns:
+    - PVC fields: `only_with: { persistence: storage_class }`
+    - Storage type sub-selector: `only_with: { persistence: storage_type }`
+    - NFS fields (dual): `only_with: { persistence: storage_type, persistence_type: nfs }`
+    - File-system fields (dual): `only_with: { persistence: storage_type, persistence_type: file-system }`
+    - External DB fields: `only_with: { postgresql_enabled: "false" }` (string, not boolean — see DAP Platform Constraints)
+    - Ingress fields: `only_with: { ingress_enabled: "true" }`
+
+For Kubernetes-related fields:
+
+- Namespace pattern: `^[a-z0-9][a-z0-9\-]{0,62}$`
+- Generic k8s resource name pattern: `^[a-z0-9][a-z0-9\-]*$`
+- K8s secret name pattern: `^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$`
+- Secret data key pattern: `^[a-zA-Z0-9._\-]+$`
+- DNS hostname pattern (allow empty): `^$|^[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)+$`
+
+## Input Group Rules
+
+- Every input must appear in exactly one `input_groups` section.
+- Group order should follow:
+  1. credentials
+  2. infrastructure
+  3. persistence
+  4. database
+  5. chart_settings
+  6. licensing
+  7. networking
+- Group `index` and input `display.index` values must be deterministic and contiguous.
+
+## Node Template Rules
+
+### Helm-Based Blueprints
+
+- Keep Helm flow layered:
+  1. `dell.nodes.helm.Binary`
+  2. `dell.nodes.helm.Repo`
+  3. `dell.nodes.helm.Release`
+- Multiple Helm releases are allowed (e.g., ingress-nginx + jfrog-platform). Use `depends_on` to enforce installation order.
+- Use `capabilities.scalable.default_instances` tied to an **integer** input to conditionally deploy optional releases (0 when disabled, 1 when enabled).
+- Use anchors for repeated resource config blocks when practical.
+- Prefer `set_values` for explicit chart toggles and `values_file` for profile-sized overrides.
+- Ensure all user-facing tunables map from `get_input` rather than hardcoded values.
+- All Helm releases must include `atomic`, `wait`, and `timeout` flags.
+
+### Kubernetes Resource Nodes
+
+For blueprints that need to create K8s resources (Namespace, Secret) before Helm install:
+
+- Use `dell.nodes.kubernetes.resources.Namespace` for namespace creation.
+- Use `dell.nodes.kubernetes.resources.Secret` for K8s secrets (credentials, license).
+- These require the Kubernetes plugin (`plugin:kubernetes-plugin?version= >=3.3.0.0,<4.0.0.0`).
+- Secret nodes must `depends_on` the namespace node.
+- Helm release nodes must `depends_on` all prerequisite secret nodes.
+
+```yaml
+create_namespace:
+  type: dell.nodes.kubernetes.resources.Namespace
+  properties:
+    client_config: { get_secret: { get_input: k8s_credentials } }
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: { get_input: namespace }
+
+license_secret:
+  type: dell.nodes.kubernetes.resources.Secret
+  properties:
+    client_config: { get_secret: { get_input: k8s_credentials } }
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: jfrog-platform-license
+        namespace: { get_input: namespace }
+      type: Opaque
+      stringData:
+        artifactory.lic:
+          get_secret: { get_input: license_secret_ref }
+    options:
+      namespace: { get_input: namespace }
+  capabilities:
+    scalable:
+      properties:
+        default_instances: { get_input: create_license_secret }
+  relationships:
+    - target: create_namespace
+      type: dell.relationships.depends_on
+```
+
+### Conditional Scaling
+
+Use `type: integer` with `valid_values: [0, 1]` for conditional deployment. DAP cannot convert `type: boolean` to the integer required by `default_instances`.
+
+```yaml
+install_ingress_controller:
+  type: integer
+  default: 0
+  constraints:
+    - valid_values: [0, 1]
+      error_message: Must be 0 (skip) or 1 (install).
+
+# In node template:
+capabilities:
+  scalable:
+    properties:
+      default_instances: { get_input: install_ingress_controller }
+```
+
+### Visible Integer Toggle Pattern for Conditional Resources
+
+DAP hidden integer inputs with `only_with` do **not** reliably resolve to `0` when the condition is unmet. Do not rely on hidden integer toggles for mutual exclusion.
+
+Instead, use **visible** user-controlled integer toggles:
+
+```yaml
+# User-facing mode selector (inputs.yaml)
+postgresql_enabled:
+  type: string
+  default: "true"
+  constraints:
+    - valid_values: ["true", "false"]
+
+# Visible toggle for bundled (inputs.yaml)
+create_bundled_db_secret:
+  type: integer
+  hidden: false
+  default: 0
+  only_with:
+    postgresql_enabled: "true"
+  constraints:
+    - valid_values: [0, 1]
+
+# Visible toggle for external (inputs.yaml)
+create_external_db_secret:
+  type: integer
+  hidden: false
+  default: 0
+  only_with:
+    postgresql_enabled: "false"
+  constraints:
+    - valid_values: [0, 1]
+```
+
+Both nodes are mutually exclusive and each `depends_on` the namespace node:
+
+```yaml
+database_credentials_bundled:
+  type: dell.nodes.kubernetes.resources.Secret
+  capabilities:
+    scalable:
+      properties:
+        default_instances: { get_input: create_bundled_db_secret }
+  relationships:
+    - target: create_namespace
+      type: dell.relationships.depends_on
+
+database_credentials_external:
+  type: dell.nodes.kubernetes.resources.Secret
+  capabilities:
+    scalable:
+      properties:
+        default_instances: { get_input: create_external_db_secret }
+  relationships:
+    - target: create_namespace
+      type: dell.relationships.depends_on
+```
+
+**Bundled mode:** user sets `create_bundled_db_secret: 1`, external stays `0`.
+**External mode:** user sets `create_external_db_secret: 1`, bundled stays `0`.
+
+### ServiceComponent Composition (k8s_stack Pattern)
+
+For orchestrating multiple sub-blueprints, use `dell.nodes.ServiceComponent`:
+
+```yaml
+install_metallb:
+  type: dell.nodes.ServiceComponent
+  properties:
+    resource_config:
+      blueprint:
+        id: { get_input: [blueprint_ids, metallb] }
+        external_resource: true
+        revision_id: { get_input: metallb_revision_id }
+      deployment:
+        display_name:
+          concat:
+            - { get_sys: [deployment, name] }
+            - "-metallb"
+        inputs:
+          start_ip: { get_input: start_ip }
+  relationships:
+    - type: dell.relationships.depends_on
+      target: install_k8s
+```
+
+This pattern is used by k8s_stack for large multi-component deployments. For single-chart Helm blueprints, direct `dell.nodes.helm.*` nodes are preferred.
+
+## DAP Platform Constraints
+
+These are hard-learned constraints from the Dell Application Platform (Cloudify-based orchestrator). Violating them causes deployment failures.
+
+### Boolean Types and Helm
+
+DAP passes Python `True`/`False` to the Helm plugin, but Helm expects lowercase `"true"`/`"false"`. **Never use `type: boolean`** for values passed to Helm `set_values`. Use `type: string` with `valid_values: ["true", "false"]` instead:
+
+```yaml
+postgresql_enabled:
+  type: string
+  default: "true"
+  constraints:
+    - valid_values: ["true", "false"]
+      error_message: Must be true or false.
+```
+
+When referencing these in `only_with`, use the string value:
+```yaml
+only_with:
+  postgresql_enabled: "false"
+```
+
+### Dict Values in set_values
+
+The Helm plugin raises `unhashable type: 'dict'` when dict-lookup patterns (nested `get_input` from a dict input) are used inside `set_values`. **Use simple `type: string` hidden inputs** instead of dict-based toggles for any value that flows into `set_values`:
+
+```yaml
+# CORRECT — simple string input (visible, not hidden)
+nginx_enabled:
+  type: string
+  hidden: false
+  default: "true"
+  constraints:
+    - valid_values: ["true", "false"]
+
+# In set_values:
+- name: artifactory.nginx.enabled
+  value: { get_input: nginx_enabled }
+```
+
+Dict-lookup patterns remain valid for `default_instances` and other non-`set_values` contexts.
+
+### Secret Inputs and K8s Secrets
+
+`type: secret_key` inputs resolve to `None` when hidden via `only_with`. **Never** use them directly in Helm `set_values`. Instead, write secret values to K8s Secret nodes and reference the secrets from Helm:
+
+```yaml
+# WRONG — secret_key in set_values, breaks when hidden
+- name: global.database.adminPassword
+  value: { get_secret: { get_input: database_admin_password } }
+
+# CORRECT — K8s Secret node with scalable toggle
+database_credentials_external:
+  type: dell.nodes.kubernetes.resources.Secret
+  properties:
+    definition:
+      stringData:
+        db-admin-password:
+          get_secret: { get_input: database_admin_password }
+  capabilities:
+    scalable:
+      properties:
+        default_instances: { get_input: create_external_db_secret }
+
+# In Helm set_values — reference the K8s secret
+- name: global.database.secrets.adminPassword.name
+  value: jfrog-platform-database-creds
+- name: global.database.secrets.adminPassword.key
+  value: db-admin-password
+```
+
+For values that include numeric components (e.g., JDBC URLs with port numbers), construct them via `concat` in the K8s Secret `stringData` to avoid Helm `--set` int64 coercion:
+
+```yaml
+db-url:
+  concat:
+    - "jdbc:postgresql://"
+    - { get_input: database_host }
+    - ":"
+    - { get_input: database_port }
+    - "/artifactory?sslmode="
+    - { get_input: database_ssl_mode }
+```
+
+### Input Derivation
+
+DAP **cannot** derive one input's value from another. Use **visible integer toggles** (see Visible Integer Toggle Pattern above) with `only_with` conditions to control conditional resources. For direct visible inputs, chain them with `only_with`:
+
+```yaml
+nginx_enabled:
+  type: string
+  hidden: false
+  default: "true"
+  display:
+    group: networking
+    index: 0
+
+ingress_enabled:
+  type: string
+  hidden: false
+  default: "false"
+  only_with:
+    nginx_enabled: "false"
+  display:
+    group: networking
+    index: 1
+
+ingress_class_name:
+  only_with:
+    ingress_enabled: "true"
+```
+
+### Values File Resolution
+
+The Helm plugin **only** resolves file paths for the `values_file` property (downloads to a temp location). Paths in `--values` flags under `flags:` are passed raw to the Helm CLI and **will not resolve** on the DAP manager filesystem. Solution: merge additional values into the `values_file` at build time using `scripts/merge_nginx_config.py`.
+
+### License Configuration
+
+License content is stored in a DAP general secret and written to a K8s Secret node (`jfrog-platform-license`) via `dell.nodes.kubernetes.resources.Secret`. The Helm chart references the K8s secret instead of receiving inline license text:
+
+```yaml
+# K8s Secret node (in 00_namespace_and_secrets.yaml)
+license_secret:
+  type: dell.nodes.kubernetes.resources.Secret
+  properties:
+    definition:
+      stringData:
+        artifactory.lic:
+          get_secret: { get_input: license_secret_ref }
+  capabilities:
+    scalable:
+      properties:
+        default_instances: { get_input: create_license_secret }
+
+# Helm set_values (in 02_jfrog_platform.yaml)
+- name: artifactory.artifactory.license.secret
+  value: jfrog-platform-license
+- name: artifactory.artifactory.license.dataKey
+  value: artifactory.lic
+```
+
+The `license_secret_ref` input should be `type: secret_key` with `type: general` constraint. The DAP secret must contain the raw license text (not base64-encoded). The `create_license_secret` integer input controls whether the K8s secret is created (1) or skipped (0, trial mode).
+
+### Database Credentials via K8s Secrets
+
+Database credentials (admin password, user, password, JDBC URL) are written to a K8s Secret before Helm install. Two mutually exclusive nodes handle bundled and external modes:
+
+- **Bundled node** (visible `create_bundled_db_secret: 0/1`, `only_with: postgresql_enabled: "true"`): Creates `jfrog-platform-database-creds` with bundled defaults (`postgres`, `artifactory`, `artifactory`) and JDBC URL via `concat`.
+- **External node** (visible `create_external_db_secret: 0/1`, `only_with: postgresql_enabled: "false"`): Creates the same-named K8s secret with values from DAP general secrets (`get_secret: { get_input: ... }`) and JDBC URL via `concat`.
+- Both nodes `depends_on` the namespace node. They are mutually exclusive (only one is active based on the user's `postgresql_enabled` selection and the corresponding toggle).
+
+Both nodes write to the same K8s secret name (`jfrog-platform-database-creds`). The Helm chart references credentials via `database.secrets.*.name` and `database.secrets.*.key`.
+
+### Database Host Default
+
+When using bundled PostgreSQL (`postgresql.enabled=true`), `global.database.host` must point to the bundled service (`{release_name}-postgresql`), not be empty. An empty `--set global.database.host=''` overrides the chart's auto-detection and causes the `postgres-setup-init` container to connect to `localhost`. Set the `database_host` input default to `jfrog-platform-postgresql` (matching the default `release_name`).
+
+### NGINX mainConf
+
+Use the chart's `nginx.mainConf` value (not `additionalResources` + `customConfigMap`) to override the default `nginx.conf`. This is merged into sizing templates at build time by `scripts/merge_nginx_config.py`. The Go template whitespace trim modifiers (`{{-`/`-}}`) are stripped during extraction so the rendered config preserves newlines between directives.
+
+### Integer for Scalable Instances
+
+`capabilities.scalable.default_instances` requires an integer. DAP cannot convert `type: boolean` to integer. Use `type: integer` with `valid_values: [0, 1]`.
+
+## Build-Time Artifacts
+
+Generated files (networking config, sizing templates) are **not** committed to source.
+They live under the `build/` directory (gitignored) and are produced at build time by
+scripts in `scripts/`:
+
+- `scripts/sync_sizing_templates.sh` → `target/sizing/`
+- `scripts/sync_networking_modes.sh` → `build/nginx-main-conf.txt` (raw nginx.conf with `worker_processes` overridden and Go template trim modifiers stripped)
+- `scripts/merge_nginx_config.py` — inserts `nginx.mainConf` into each sizing template's `nginx:` block
+
+The `Makefile` orchestrates the build:
+
+1. `sync` — downloads sizing templates and extracts the nginx main conf from the Helm chart
+2. `zip_blueprint` — stages files, patches chart version, merges `mainConf` into sizing templates, and zips
+
+The source blueprint has **no** nginx config override (works with chart defaults for testing). The built zip has `mainConf` merged into sizing templates so the single `values_file` contains the complete NGINX configuration.
+
+## Safety and Operability
+
+- Disable non-required JFrog services explicitly (for example, xray/distribution/rabbitmq) unless the blueprint intent requires them.
+- Keep persistence and storage class controls explicit.
+- Do not embed secrets or credentials in blueprint defaults.
+- Keep service exposure choice explicit (`LoadBalancer`, ingress, gateway API).
+
+## Outputs and UX
+
+- Expose operationally useful outputs (release name, namespace, endpoint URL, applied profile).
+- Keep display labels concise and human-readable for catalog users.
+
+## Change Discipline
+
+When editing existing blueprints:
+
+- Do not rename existing inputs unless backward compatibility is addressed.
+- Do not change default values silently when it alters deployment behavior.
+- If behavior changes, add a `CHANGELOG.yaml` entry with ticket, developer, and description.
+
+## Labels
+
+- `labels` must include `csys-obj-type: environment`.
+- `blueprint_labels` must include `obj-type` (e.g., `helm`) and `csys-obj-type: environment`.
+- For k8s_stack-style blueprints, additional labels may include `target_environment`, `solution`, and `version`.
+
+## Validation Checklist (run before commit)
+
+- YAML parses without syntax errors.
+- Copyright header is present on all YAML files.
+- All `get_input` references resolve to defined inputs.
+- All input groups reference existing inputs.
+- All `only_with` references point to valid parent inputs and values.
+- All regex constraints are anchored and match intended k8s naming rules.
+- Helm chart version input remains semver (`^\d+\.\d+\.\d+$`) unless a documented exception is required.
+- Every `depends_on` target exists as a node template.
+- Conditional nodes use `scalable.default_instances` tied to an integer input.
+- `valid_values` contain raw values only (no descriptive text).
+- No `type: boolean` inputs flow into Helm `set_values` (use `type: string` with `"true"`/`"false"`).
+- No dict-lookup patterns used inside `set_values` (use simple string inputs).
+- License uses K8s Secret node with scalable toggle, referenced via `license.secret` + `dataKey` in Helm.
+- Database credentials use K8s Secret nodes with visible user-controlled integer toggles (bundled + external, mutually exclusive).
+- JDBC URL is constructed via `concat` in K8s Secret `stringData` (not passed through `--set`).
+- No `type: secret_key` inputs used directly in Helm `set_values` (use K8s Secret nodes instead).
+- Visible user-controlled integer toggles have `only_with` conditions tied to user-facing mode selectors. No hidden integer toggles for mutual exclusion.
+- All K8s Secret and Namespace nodes use `dell.relationships.depends_on` for correct ordering.
+
+## Assistant Behavior
+
+When generating blueprint changes:
+
+- Preserve existing ordering and style.
+- Propose minimal diffs.
+- Include changelog updates for behavior changes.
+- Explain any intentional compatibility break in the PR description.

--- a/JFrog-dell-blueprints/.githooks/pre-commit
+++ b/JFrog-dell-blueprints/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+"$REPO_ROOT/scripts/validate_blueprints.sh"

--- a/JFrog-dell-blueprints/.gitignore
+++ b/JFrog-dell-blueprints/.gitignore
@@ -1,0 +1,2 @@
+target/
+build/

--- a/JFrog-dell-blueprints/.yamllint
+++ b/JFrog-dell-blueprints/.yamllint
@@ -1,0 +1,27 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 200
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+  document-start: disable
+  truthy:
+    check-keys: false
+  indentation:
+    indent-sequences: consistent
+  comments:
+    min-spaces-from-content: 1
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+
+ignore: |
+  target/
+  .githooks/

--- a/JFrog-dell-blueprints/CODEOWNERS
+++ b/JFrog-dell-blueprints/CODEOWNERS
@@ -1,0 +1,1 @@
+* @srinivasgowda097

--- a/JFrog-dell-blueprints/CONTRIBUTIONS.md
+++ b/JFrog-dell-blueprints/CONTRIBUTIONS.md
@@ -1,0 +1,21 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. There are just a few guidelines you need to follow.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License Agreement. You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project.
+
+You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project), you probably don't need to do it again.
+
+## Making Changes
+
+1. Fork the repository and create your branch from `master`.
+2. Make your changes to the blueprint YAML files or scripts.
+3. Test your changes by validating the blueprint syntax and, if possible, deploying to a test environment.
+4. Ensure your changes follow the existing TOSCA `dell_1_1` conventions used in the project.
+5. Submit a pull request.
+
+## Code Reviews
+
+All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more information on using pull requests.

--- a/JFrog-dell-blueprints/LICENSE
+++ b/JFrog-dell-blueprints/LICENSE
@@ -1,0 +1,193 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (which shall not include communications that are clearly marked or
+      otherwise designated in writing by the copyright owner as "Not a Contribution").
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to use, reproduce, modify, merge, publish,
+      distribute, sublicense, and/or sell copies of the Work, and to
+      permit persons to whom the Work is furnished to do so, subject to
+      the following conditions:
+
+      The above copyright notice and this permission notice shall be
+      included in all copies or substantial portions of the Work.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, trademark, patent, and
+          other attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright notice to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Support. A product may include
+      a warranty or support agreement offered by a Contributor. You may
+      accept such warranty or support agreement, but You are not required
+      to do so. The terms and conditions of any such warranty or support
+      agreement are between You and the Contributor offering such warranty
+      or support agreement.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!) The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same page as the copyright notice for easier identification within
+      third-party archives.
+
+   Copyright 2026 JFrog Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/JFrog-dell-blueprints/Makefile
+++ b/JFrog-dell-blueprints/Makefile
@@ -1,0 +1,77 @@
+SHELL := /bin/bash
+
+# --- Paths ---
+BLUEPRINT_NAME        := jfrog-platform
+BLUEPRINT_DIR         := blueprints/$(BLUEPRINT_NAME)
+ZIP_NAME              := jfrog-dell
+VERSION               ?= local
+CHART_VERSION         ?=
+ZIP_OUTPUT_DIR        := target
+ZIP_EXCLUDES          := '*/tests/*' '*.test*'
+
+PACKAGE_ROOT          := $(ZIP_NAME)-$(VERSION)
+STAGING_DIR           := $(ZIP_OUTPUT_DIR)/.$(PACKAGE_ROOT)
+
+# --- Sync Artifacts from Helm Chart ---
+sync_sizing:
+ifneq ($(strip $(CHART_VERSION)),)
+	./scripts/sync_sizing_templates.sh "$(CHART_VERSION)"
+else
+	./scripts/sync_sizing_templates.sh
+endif
+
+sync_nginx_conf:
+ifneq ($(strip $(CHART_VERSION)),)
+	./scripts/sync_networking_modes.sh "$(CHART_VERSION)"
+else
+	./scripts/sync_networking_modes.sh
+endif
+
+sync: sync_sizing sync_nginx_conf
+
+# --- Resolve Chart Version ---
+resolve_chart_version:
+ifneq ($(strip $(CHART_VERSION)),)
+	$(eval RESOLVED_CHART_VERSION := $(CHART_VERSION))
+else
+	$(eval RESOLVED_CHART_VERSION := $(shell ./scripts/get_latest_jfrog_platform_version.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1))
+endif
+	@if [ -z "$(RESOLVED_CHART_VERSION)" ]; then \
+		echo "Error: Unable to resolve Helm chart version." >&2; \
+		exit 1; \
+	fi
+	@echo "Chart version: $(RESOLVED_CHART_VERSION)"
+
+# --- Blueprint Zipping ---
+zip_blueprint: sync resolve_chart_version
+	@rm -rf "$(STAGING_DIR)"
+	@mkdir -p "$(STAGING_DIR)/$(PACKAGE_ROOT)"
+	cp "$(BLUEPRINT_DIR)/blueprint.yaml"  "$(STAGING_DIR)/$(PACKAGE_ROOT)/blueprint.yaml"
+	cp "$(BLUEPRINT_DIR)/CHANGELOG.yaml"  "$(STAGING_DIR)/$(PACKAGE_ROOT)/CHANGELOG.yaml"
+	cp -R "$(BLUEPRINT_DIR)/top_level"    "$(STAGING_DIR)/$(PACKAGE_ROOT)/top_level"
+	cp -R "$(BLUEPRINT_DIR)/application"  "$(STAGING_DIR)/$(PACKAGE_ROOT)/application"
+	cp -R target/sizing                   "$(STAGING_DIR)/$(PACKAGE_ROOT)/sizing"
+	perl -0pi -e "s/default:\s*0\.0\.0/default: $(RESOLVED_CHART_VERSION)/" \
+		"$(STAGING_DIR)/$(PACKAGE_ROOT)/top_level/inputs_hidden.yaml"
+	@echo "Merging nginx mainConf into sizing templates..."
+	@python3 scripts/merge_nginx_config.py \
+		build/nginx-main-conf.txt \
+		"$(STAGING_DIR)/$(PACKAGE_ROOT)/sizing"
+	cd "$(STAGING_DIR)" && zip -r "$(CURDIR)/$(ZIP_OUTPUT_DIR)/$(ZIP_NAME)-$(VERSION).zip" \
+		"$(PACKAGE_ROOT)" -x $(ZIP_EXCLUDES)
+	@rm -rf "$(STAGING_DIR)"
+	@echo "Done: $(ZIP_OUTPUT_DIR)/$(ZIP_NAME)-$(VERSION).zip"
+
+# --- Validate ---
+validate:
+	./scripts/validate_blueprints.sh
+
+# --- Clean ---
+clean:
+	rm -rf target/ build/
+
+# --- Full Build ---
+all: zip_blueprint
+
+.PHONY: sync sync_sizing sync_nginx_conf resolve_chart_version \
+        zip_blueprint validate clean all

--- a/JFrog-dell-blueprints/NOTICE
+++ b/JFrog-dell-blueprints/NOTICE
@@ -1,0 +1,16 @@
+jfrog-dell-blueprints
+Copyright 2026 JFrog Ltd.
+
+This project contains Dell TOSCA blueprints for deploying JFrog products
+on Kubernetes clusters via the Dell Application Platform (DAP).
+
+This project uses the following third-party components:
+
+JFrog Platform Helm Chart:
+- jfrog/jfrog-platform - https://github.com/jfrog/charts - Licensed under Apache License 2.0
+
+Dell Application Platform:
+- Dell TOSCA types and Helm plugin - Proprietary, provided by Dell Technologies
+
+Any modifications or contributions to this project should include
+appropriate attributions as described in the above licenses.

--- a/JFrog-dell-blueprints/README.md
+++ b/JFrog-dell-blueprints/README.md
@@ -1,0 +1,263 @@
+# JFrog Dell Blueprints
+
+Dell Blueprints that deploy JFrog products onto Kubernetes clusters using the Dell Application Platform (DAP). Each blueprint is a TOSCA-based definition (`dell_1_1`) that wraps an official JFrog Platform Helm chart and exposes it as a self-service catalog item within DAP.
+
+## Available Blueprints
+
+### jfrog-platform
+
+Deploys **JFrog Platform (Artifactory)** on a Kubernetes cluster using the official `jfrog/jfrog-platform` Helm chart.
+
+**What it provisions:**
+
+- Kubernetes Namespace (created before Helm install via Kubernetes plugin)
+- JFrog Artifactory with NGINX reverse-proxy (LoadBalancer service)
+- PostgreSQL with persistent storage (bundled or external)
+- Kubernetes Secrets for database credentials and license (created via Kubernetes plugin before Helm install)
+- Configurable sizing templates (`xsmall` through `2xlarge`)
+- Optional NGINX Ingress Controller and Kubernetes Ingress for external access
+- Custom NGINX `mainConf` with optimised `worker_processes` (merged into sizing templates at build time)
+
+**Inputs:**
+
+| Group | Input | Description | Default |
+|---|---|---|---|
+| Credentials | `k8s_credentials` | DAP secret storing Kubernetes credentials (ssl_ca_cert, token) | — |
+| Infrastructure | `namespace` | Target Kubernetes namespace | `jfrog-platform` |
+| Persistence | `persistence` | Persistence mode: `storage_class` (PVC) or `storage_type` (file-system/nfs) | `storage_class` |
+| Persistence | `persistence_type` | Storage type: `file-system` or `nfs` (visible when `storage_type` selected) | `file-system` |
+| Persistence | `filesystem_cache_enabled` | Enable local file-system cache (`"true"` / `"false"`) | `"false"` |
+| Persistence | `storage_class` | Kubernetes StorageClass name (visible when `storage_class` selected) | `""` (cluster default) |
+| Persistence | `pvc_access_mode` | PVC access mode (visible when `storage_class` selected) | `ReadWriteOnce` |
+| Persistence | `pvc_size` | PVC storage size (visible when `storage_class` selected) | `20Gi` |
+| Persistence | `nfs_ip` | NFS server IP address (visible for nfs) | — |
+| Persistence | `nfs_capacity` | NFS storage capacity (visible for nfs) | `200Gi` |
+| Database | `postgresql_enabled` | Deploy bundled PostgreSQL subchart (`"true"` / `"false"`) | `"true"` |
+| Database | `create_bundled_db_secret` | Create K8s secret with bundled DB credentials: 0 = No, 1 = Yes (visible when bundled) | `0` |
+| Database | `create_external_db_secret` | Create K8s secret with external DB credentials: 0 = No, 1 = Yes (visible when external) | `0` |
+| Database | `database_admin_password` | DAP general secret for PostgreSQL admin password (visible when external) | — |
+| Database | `database_host` | PostgreSQL hostname (visible when external) | `jfrog-platform-postgresql` |
+| Database | `database_port` | PostgreSQL port (visible when external) | `5432` |
+| Database | `database_ssl_mode` | PostgreSQL SSL mode (visible when external) | `disable` |
+| Database | `database_user` | DAP general secret for database username (visible when external) | — |
+| Database | `database_password` | DAP general secret for database password (visible when external) | — |
+| Chart Settings | `release_name` | Helm release name | `jfrog-platform` |
+| Chart Settings | `chart_version` | Helm chart version (injected at build time) | `0.0.0` |
+| Chart Settings | `sizing_template` | Resource sizing profile (see Sizing Templates below) | `small` |
+| Licensing | `create_license_secret` | Create K8s license secret: 0 = No (trial mode), 1 = Yes | `0` |
+| Licensing | `license_secret_ref` | DAP general secret containing raw Artifactory license text | — |
+| Networking | `nginx_enabled` | Bundled NGINX with LoadBalancer (`"true"` / `"false"`) | `"true"` |
+| Networking | `ingress_enabled` | Kubernetes Ingress (visible when NGINX disabled) | `"false"` |
+| Networking | `install_ingress_controller` | Install ingress-nginx controller: 0 = No, 1 = Yes (visible for ingress) | `0` |
+| Networking | `ingress_class_name` | Kubernetes IngressClass name (visible for ingress) | `nginx` |
+| Networking | `ingress_host` | DNS hostname for the Ingress resource (visible for ingress) | `""` |
+
+**Hidden inputs (auto-controlled):**
+
+No hidden database toggles. Both `create_bundled_db_secret` and `create_external_db_secret` are user-controlled visible inputs.
+
+**Sizing Templates:**
+
+| Template | Replicas | Artifactory CPU / Memory | PostgreSQL Memory | Recommended For |
+|---|---|---|---|---|
+| `xsmall` | 1 | 1 CPU / 4 Gi | 8 Gi | Dev/test, minimum viable |
+| `small` | 1 | 1 CPU / 5 Gi | 16 Gi | Small teams (~50 users) |
+| `medium` | 2 | 1 CPU / 5 Gi each | 32 Gi | Medium teams, HA (~500 users) |
+| `large` | 3 | 2 CPU / 12 Gi each | 64 Gi | Large organizations (~2000 users) |
+| `xlarge` | 4 | 2 CPU / 16 Gi each | 128 Gi | Very large organizations (~5000 users) |
+| `2xlarge` | 6 | 4 CPU / 24 Gi each | 256 Gi | Enterprise-scale (5000+ users) |
+
+> **Note:** Medium and above require Enterprise licenses (one per replica). CPU/Memory values shown are for the Artifactory main container only; each tier also scales NGINX, Router, Access, Metadata, and other sidecar containers proportionally.
+
+**Outputs:**
+
+| Capability | Description |
+|---|---|
+| `release_name` | Deployed Helm release name |
+| `namespace` | Kubernetes namespace of the deployment |
+| `sizing` | Applied sizing template |
+| `platform_url_ingress` | Artifactory URL when using ingress deployment mode |
+| `platform_url_command` | kubectl command to get LoadBalancer IP (nginx mode) |
+
+## Examples
+
+The `examples/` directory contains sample input configurations for common deployment scenarios. These are **not** included in the release zip — they are for reference only.
+
+| Example | Description |
+|---|---|
+| [bundled-postgres-trial.yaml](examples/bundled-postgres-trial.yaml) | Simplest deployment — bundled PostgreSQL, trial mode, LoadBalancer |
+| [bundled-postgres-licensed.yaml](examples/bundled-postgres-licensed.yaml) | Bundled PostgreSQL with license from DAP secret |
+| [external-postgres-licensed.yaml](examples/external-postgres-licensed.yaml) | External PostgreSQL with credentials from DAP secrets |
+| [ingress-mode.yaml](examples/ingress-mode.yaml) | Kubernetes Ingress mode with optional ingress-nginx controller |
+| [ha-production.yaml](examples/ha-production.yaml) | Full HA production: external DB, HA license, Ingress, PVC storage |
+
+Each file includes DAP UI steps and explains what happens behind the scenes (hidden toggles, K8s Secrets created, etc.).
+
+## Repository Structure
+
+```
+├── .github/workflows/
+│   ├── dell-release.yaml                   # GitHub Actions – builds zip & publishes release
+│   └── dell-validate-blueprints.yaml       # PR validation workflow
+├── blueprints/
+│   └── jfrog-platform/
+│       ├── blueprint.yaml                  # Top-level imports, labels (thin file)
+│       ├── CHANGELOG.yaml                  # Version changelog
+│       ├── top_level/
+│       │   ├── inputs.yaml                 # User-visible inputs + input_groups
+│       │   ├── inputs_hidden.yaml          # Hidden/auto-controlled inputs
+│       │   └── outputs.yaml                # Capabilities (outputs)
+│       └── application/
+│           ├── 00_namespace_and_secrets.yaml  # K8s Namespace + Secrets (license, DB creds)
+│           ├── 01_ingress_nginx.yaml          # Ingress-nginx Helm release (conditional)
+│           └── 02_jfrog_platform.yaml         # JFrog Platform Helm release
+├── Makefile                                # Build, sync, validate, clean targets
+├── scripts/
+│   ├── release.sh                          # Interactive release helper
+│   ├── sync_sizing_templates.sh            # Sync sizing templates from chart
+│   ├── sync_networking_modes.sh            # Extract nginx mainConf from chart
+│   ├── merge_nginx_config.py              # Merge nginx mainConf into sizing templates
+│   ├── validate_blueprints.sh              # Local/CI blueprint validator
+│   └── get_latest_jfrog_platform_version.sh
+├── examples/                               # Sample input configs (not in zip)
+│   ├── bundled-postgres-trial.yaml
+│   ├── bundled-postgres-licensed.yaml
+│   ├── external-postgres-licensed.yaml
+│   ├── ingress-mode.yaml
+│   └── ha-production.yaml
+├── build/                                  # (gitignored) build-time artifacts
+│   └── nginx-main-conf.txt                 # Extracted nginx.conf from chart (worker_processes overridden)
+└── README.md
+```
+
+## Prerequisites
+
+- **Dell Application Platform (DAP)** with the Helm plugin (`>=1.4.0.0, <2.0.0.0`) and Kubernetes plugin (`>=3.3.0.0, <4.0.0.0`)
+- A Kubernetes cluster with a valid kubeconfig stored as a DAP secret (`type: k8s`)
+- **For licensed deployments:** An Artifactory license stored as a **DAP general secret** containing the raw license text (starting with `products:`). Do **not** base64-encode the value — the Helm chart handles encoding internally. Set `create_license_secret` to `1` and select the secret as `license_secret_ref` when deploying. If omitted (`create_license_secret: 0`), Artifactory starts in trial mode.
+- **For external database:** Three DAP general secrets storing the PostgreSQL admin password, application database username, and application database password. These are referenced by `database_admin_password`, `database_user`, and `database_password` inputs (visible when `postgresql_enabled` is `"false"`). Set `create_external_db_secret` to `1` to create the K8s secret with these values.
+
+## Blueprint Validation
+
+Blueprint validation runs automatically in pull requests via the GitHub Actions workflow `Validate Dell Blueprints`.
+
+Run the same validator locally:
+
+```bash
+./scripts/validate_blueprints.sh
+```
+
+For branch protection, set the required status check to:
+
+- `Validate Dell Blueprints / validate`
+
+## Releasing a New Version
+
+Releases are automated via GitHub Actions. When a version tag (`jfrog-dell-blueprints/v*`) is pushed, the workflow:
+
+1. Syncs sizing templates from the JFrog Platform Helm chart
+2. Extracts the NGINX `mainConf` from the chart (overriding `worker_processes` to prevent OOM)
+3. Merges the `mainConf` into each sizing template's `nginx:` block (so the single `values_file` contains everything)
+4. Strips Go template whitespace trim modifiers (`{{-`/`-}}`) to preserve newlines in the rendered `nginx.conf`
+5. Injects the resolved chart version into `inputs_hidden.yaml`
+6. Zips the blueprint and sizing templates into a release archive
+
+The archive extracts to a versioned root folder:
+
+- `jfrog-dell-<version>/blueprint.yaml`
+- `jfrog-dell-<version>/CHANGELOG.yaml`
+- `jfrog-dell-<version>/top_level/` (inputs, outputs)
+- `jfrog-dell-<version>/application/` (Helm release nodes)
+- `jfrog-dell-<version>/sizing/` (generated from Helm chart, with nginx config merged)
+
+The `scripts/` directory is **not** included in the release artifact — it is only used during development and CI.
+
+### Building Artifacts Locally
+
+Build the zip artifact using `make`:
+
+```bash
+make all VERSION=1.0.0
+```
+
+Specify a Helm chart version:
+
+```bash
+make all VERSION=1.0.0 CHART_VERSION=11.5.2
+```
+
+The artifact is written to `target/jfrog-dell-<VERSION>.zip`. Sizing templates and NGINX config are automatically synced from the Helm chart and merged during the build.
+
+Other useful targets:
+
+```bash
+make sync                       # Sync sizing + nginx config only
+make validate                   # Run blueprint validation
+make clean                      # Remove target/ and build/
+```
+
+### Interactive Release Process
+
+Use the helper script to walk through the release process interactively:
+
+```bash
+./scripts/release.sh
+```
+
+Or run it non-interactively:
+
+```bash
+NEW_VERSION=1.0.0 ./scripts/release.sh -y
+```
+
+The script will:
+
+1. Check out the default branch and pull latest
+2. Create a `jfrog-dell-blueprints/v<version>` branch
+3. Push the branch and create an annotated `jfrog-dell-blueprints/v<version>` tag
+4. Push the tag, which triggers the GitHub Actions workflow to build and publish the release
+
+#### Specifying Helm Chart Version in CI
+
+By default, releases sync sizing templates from the **latest** JFrog Platform Helm chart version. To use a specific chart version, trigger the workflow manually with `chart_version` input:
+
+```bash
+gh workflow run release.yaml -f chart_version=11.5.1
+```
+
+## Checking the Latest JFrog Platform Helm Chart Version
+
+Run the helper script to fetch the latest stable version from `charts.jfrog.io`:
+
+```bash
+./scripts/get_latest_jfrog_platform_version.sh
+```
+
+Use the returned version as the `chart_version` input when deploying the blueprint, or as the `CHART_VERSION` parameter when building locally.
+
+## DAP Platform Notes
+
+Some DAP/Cloudify-specific behaviors affect blueprint design:
+
+- **Boolean inputs and Helm**: DAP passes Python `True`/`False` to the Helm plugin, but Helm expects lowercase `"true"`/`"false"`. Use `type: string` with `valid_values: ["true", "false"]` for any value passed to `set_values`.
+- **Integer for scalable instances**: `capabilities.scalable.default_instances` requires an integer. DAP cannot convert `type: boolean` to integer. Use `type: integer` with `valid_values: [0, 1]`.
+- **Integer toggle pattern**: Integer inputs with `valid_values: [0, 1]` drive `scalable.default_instances` on conditional nodes. Hidden integer inputs with `only_with` do **not** reliably resolve to `0` when the condition is unmet. Both `create_bundled_db_secret` and `create_external_db_secret` are kept visible so the user explicitly controls which DB credentials secret is created.
+- **Dict values in set_values**: The Helm plugin raises `unhashable type: 'dict'` when dict-lookup patterns are used in `set_values`. Use simple `type: string` hidden inputs instead.
+- **Values file paths**: The Helm plugin only resolves file paths for the `values_file` property. Paths in `--values` flags are passed as-is to the CLI and will fail. Build-time merge into the `values_file` is the workaround.
+- **License via K8s secret**: License content is stored in a DAP general secret, then written to a K8s Secret (`jfrog-platform-license`) via `dell.nodes.kubernetes.resources.Secret`. The Helm chart references the secret via `artifactory.artifactory.license.secret` and `dataKey`. This avoids multi-line license issues with Helm `--set`.
+- **Database credentials via K8s secrets**: Database credentials are written to a K8s Secret (`jfrog-platform-database-creds`) before Helm install. Two mutually exclusive nodes handle bundled (hardcoded defaults) and external (DAP secrets) modes. The user controls which node is active via visible integer toggles: `create_bundled_db_secret` (visible when `postgresql_enabled: "true"`) and `create_external_db_secret` (visible when `postgresql_enabled: "false"`). Both default to `0`. The JDBC URL is constructed via `concat` to avoid Helm `--set` int64 port coercion (`%!g(int64=5432)`).
+- **Namespace creation**: The namespace is created explicitly via `dell.nodes.kubernetes.resources.Namespace` before secrets and Helm install. The Helm release also includes `--create-namespace` as an idempotent fallback.
+- **NGINX mainConf**: Use the chart's `nginx.mainConf` value to override the default `nginx.conf` (e.g., to set `worker_processes 4` and prevent OOM). This is merged into sizing templates at build time. The `additionalResources` + `customConfigMap` approach is unnecessary.
+- **Secret inputs and only_with**: `type: secret_key` inputs resolve to `None` when hidden via `only_with`. This is safe as long as the consuming node is also scaled to `0` (not instantiated) when the condition is not met. Hidden integer inputs with `only_with` do **not** reliably resolve to `0` when the condition is unmet - avoid relying on hidden integer toggles for mutual exclusion. Use visible user-controlled toggles instead.
+- **Networking toggles**: `nginx_enabled` and `ingress_enabled` must be user-visible inputs (not hidden). DAP cannot derive one input's value from another, so the user must explicitly set both when switching between nginx and ingress modes.
+- **Input derivation**: DAP cannot derive one input's value from another. For conditional resource creation, use visible integer toggles with `only_with` so only the relevant toggle is shown in the UI. Both nodes are mutually exclusive (each depends on `create_namespace`).
+
+## Contributing
+
+Please read [CONTRIBUTIONS.md](CONTRIBUTIONS.md) for details on how to contribute to this project.
+
+## License
+
+Copyright 2026 JFrog Ltd.
+
+Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the full license text.

--- a/JFrog-dell-blueprints/blueprints/jfrog-platform/CHANGELOG.yaml
+++ b/JFrog-dell-blueprints/blueprints/jfrog-platform/CHANGELOG.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 JFrog Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+---
+
+tosca_definitions_version: dell_1_1
+
+description: Changelog for jfrog-platform
+
+imports:
+  - dell/types/types.yaml
+
+labels:
+  csys-obj-type:
+    values:
+      - environment
+
+blueprint_labels:
+  obj-type:
+    values:
+      - helm
+  csys-obj-type:
+    values:
+      - environment
+
+dsl_definitions:
+  changelog:
+    1.0.0:
+      - ticket: INST-20783
+        developer: srinivasg@jfrog.com
+        description: >
+          Initial JFrog Platform blueprint wrapping the official
+          jfrog/jfrog-platform Helm chart.

--- a/JFrog-dell-blueprints/blueprints/jfrog-platform/application/00_namespace_and_secrets.yaml
+++ b/JFrog-dell-blueprints/blueprints/jfrog-platform/application/00_namespace_and_secrets.yaml
@@ -1,0 +1,110 @@
+# Copyright (c) 2026 JFrog Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+---
+
+node_templates:
+
+  create_namespace:
+    type: dell.nodes.kubernetes.resources.Namespace
+    properties:
+      client_config: { get_secret: { get_input: k8s_credentials } }
+      definition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: { get_input: namespace }
+
+  license_secret:
+    type: dell.nodes.kubernetes.resources.Secret
+    properties:
+      client_config: { get_secret: { get_input: k8s_credentials } }
+      definition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: jfrog-platform-license
+          namespace: { get_input: namespace }
+        type: Opaque
+        stringData:
+          artifactory.lic:
+            get_secret: { get_input: license_secret_ref }
+      options:
+        namespace: { get_input: namespace }
+    capabilities:
+      scalable:
+        properties:
+          default_instances: { get_input: create_license_secret }
+    relationships:
+      - target: create_namespace
+        type: dell.relationships.depends_on
+
+  database_credentials_bundled:
+    type: dell.nodes.kubernetes.resources.Secret
+    properties:
+      client_config: { get_secret: { get_input: k8s_credentials } }
+      definition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: jfrog-platform-database-creds
+          namespace: { get_input: namespace }
+        type: Opaque
+        stringData:
+          db-admin-password: postgres
+          db-user: artifactory
+          db-password: artifactory
+          db-url:
+            concat:
+              - "jdbc:postgresql://"
+              - { get_input: database_host }
+              - ":"
+              - { get_input: database_port }
+              - "/artifactory?sslmode="
+              - { get_input: database_ssl_mode }
+      options:
+        namespace: { get_input: namespace }
+    capabilities:
+      scalable:
+        properties:
+          default_instances: { get_input: create_bundled_db_secret }
+    relationships:
+      - target: create_namespace
+        type: dell.relationships.depends_on
+
+  database_credentials_external:
+    type: dell.nodes.kubernetes.resources.Secret
+    properties:
+      client_config: { get_secret: { get_input: k8s_credentials } }
+      definition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: jfrog-platform-database-creds
+          namespace: { get_input: namespace }
+        type: Opaque
+        stringData:
+          db-admin-password:
+            get_secret: { get_input: database_admin_password }
+          db-user:
+            get_secret: { get_input: database_user }
+          db-password:
+            get_secret: { get_input: database_password }
+          db-url:
+            concat:
+              - "jdbc:postgresql://"
+              - { get_input: database_host }
+              - ":"
+              - { get_input: database_port }
+              - "/artifactory?sslmode="
+              - { get_input: database_ssl_mode }
+      options:
+        namespace: { get_input: namespace }
+    capabilities:
+      scalable:
+        properties:
+          default_instances: { get_input: create_external_db_secret }
+    relationships:
+      - target: create_namespace
+        type: dell.relationships.depends_on

--- a/JFrog-dell-blueprints/blueprints/jfrog-platform/application/01_ingress_nginx.yaml
+++ b/JFrog-dell-blueprints/blueprints/jfrog-platform/application/01_ingress_nginx.yaml
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 JFrog Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+---
+
+dsl_definitions:
+  ingress_nginx_repo_config: &ingress_nginx_repo_config
+    name: ingress-nginx
+    repo_url: https://kubernetes.github.io/ingress-nginx
+
+node_templates:
+
+  ingress_nginx_repo:
+    type: dell.nodes.helm.Repo
+    properties:
+      resource_config: *ingress_nginx_repo_config
+    relationships:
+      - target: helm_binary
+        type: dell.relationships.helm.run_on_host
+
+  ingress_nginx_release:
+    type: dell.nodes.helm.Release
+    properties:
+      client_config: { get_secret: { get_input: k8s_credentials } }
+      resource_config:
+        name: ingress-nginx
+        chart: ingress-nginx/ingress-nginx
+        set_values:
+          - name: controller.config.use-forwarded-headers
+            value: "true"
+        flags:
+          - name: namespace
+            value: ingress-nginx
+          - name: create-namespace
+          - name: version
+            value: { get_input: ingress_nginx_version }
+          - name: atomic
+          - name: wait
+          - name: timeout
+            value: "5m0s"
+    capabilities:
+      scalable:
+        properties:
+          default_instances: { get_input: install_ingress_controller }
+    relationships:
+      - target: helm_binary
+        type: dell.relationships.helm.run_on_host
+      - target: ingress_nginx_repo
+        type: dell.relationships.depends_on

--- a/JFrog-dell-blueprints/blueprints/jfrog-platform/application/02_jfrog_platform.yaml
+++ b/JFrog-dell-blueprints/blueprints/jfrog-platform/application/02_jfrog_platform.yaml
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 JFrog Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+---
+
+dsl_definitions:
+  jfrog_repo_config: &jfrog_repo_config
+    name: jfrog
+    repo_url: https://charts.jfrog.io
+
+node_templates:
+
+  helm_binary:
+    type: dell.nodes.helm.Binary
+
+  jfrog_repo:
+    type: dell.nodes.helm.Repo
+    properties:
+      resource_config: *jfrog_repo_config
+    relationships:
+      - target: helm_binary
+        type: dell.relationships.helm.run_on_host
+
+  jfrog_platform_release:
+    type: dell.nodes.helm.Release
+    properties:
+      client_config: { get_secret: { get_input: k8s_credentials } }
+      resource_config:
+        name: { get_input: release_name }
+        chart: jfrog/jfrog-platform
+        values_file:
+          concat:
+            - "sizing/platform-"
+            - { get_input: sizing_template }
+            - ".yaml"
+        set_values:
+          - name: artifactory.enabled
+            value: "true"
+          - name: artifactory.artifactory.persistence.enabled
+            value: "true"
+          - name: artifactory.artifactory.persistence.type
+            value: { get_input: persistence_type }
+          - name: artifactory.artifactory.persistence.storageClassName
+            value: { get_input: storage_class }
+          - name: artifactory.artifactory.persistence.size
+            value: { get_input: pvc_size }
+          - name: artifactory.artifactory.persistence.accessMode
+            value: { get_input: pvc_access_mode }
+          - name: artifactory.artifactory.persistence.nfs.ip
+            value: { get_input: nfs_ip }
+          - name: artifactory.artifactory.persistence.nfs.capacity
+            value: { get_input: nfs_capacity }
+          - name: artifactory.artifactory.persistence.fileSystem.cache.enabled
+            value: { get_input: filesystem_cache_enabled }
+          - name: artifactory.nginx.enabled
+            value: { get_input: nginx_enabled }
+          - name: artifactory.ingress.enabled
+            value: { get_input: ingress_enabled }
+          - name: artifactory.ingress.className
+            value: { get_input: ingress_class_name }
+          - name: artifactory.ingress.hosts[0]
+            value: { get_input: ingress_host }
+          - name: rabbitmq.enabled
+            value: "false"
+          - name: postgresql.enabled
+            value: { get_input: postgresql_enabled }
+          - name: global.database.initDBCreation
+            value: { get_input: postgresql_enabled }
+          - name: global.database.host
+            value: { get_input: database_host }
+          - name: global.database.port
+            value: { get_input: database_port }
+          - name: global.database.sslMode
+            value: { get_input: database_ssl_mode }
+          - name: global.database.secrets.adminPassword.name
+            value: jfrog-platform-database-creds
+          - name: global.database.secrets.adminPassword.key
+            value: db-admin-password
+          - name: artifactory.database.type
+            value: "postgresql"
+          - name: artifactory.database.driver
+            value: "org.postgresql.Driver"
+          - name: artifactory.database.secrets.user.name
+            value: jfrog-platform-database-creds
+          - name: artifactory.database.secrets.user.key
+            value: db-user
+          - name: artifactory.database.secrets.password.name
+            value: jfrog-platform-database-creds
+          - name: artifactory.database.secrets.password.key
+            value: db-password
+          - name: artifactory.database.secrets.url.name
+            value: jfrog-platform-database-creds
+          - name: artifactory.database.secrets.url.key
+            value: db-url
+          - name: xray.enabled
+            value: "false"
+          - name: distribution.enabled
+            value: "false"
+          - name: artifactory.artifactory.license.secret
+            value: jfrog-platform-license
+          - name: artifactory.artifactory.license.dataKey
+            value: artifactory.lic
+        flags:
+          - name: namespace
+            value: { get_input: namespace }
+          - name: version
+            value: { get_input: chart_version }
+          - name: atomic
+          - name: wait
+          - name: create-namespace
+          - name: timeout
+            value: "10m0s"
+    relationships:
+      - target: helm_binary
+        type: dell.relationships.helm.run_on_host
+      - target: jfrog_repo
+        type: dell.relationships.depends_on
+      - target: license_secret
+        type: dell.relationships.depends_on
+      - target: database_credentials_bundled
+        type: dell.relationships.depends_on
+      - target: database_credentials_external
+        type: dell.relationships.depends_on
+      - target: ingress_nginx_release
+        type: dell.relationships.depends_on

--- a/JFrog-dell-blueprints/blueprints/jfrog-platform/blueprint.yaml
+++ b/JFrog-dell-blueprints/blueprints/jfrog-platform/blueprint.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 JFrog Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+---
+
+tosca_definitions_version: dell_1_1
+
+description: >
+  Deploys JFrog Platform (Artifactory only) on a Kubernetes cluster
+  using the official jfrog/jfrog-platform Helm chart.
+
+imports:
+  - dell/types/types.yaml
+  - plugin:helm-plugin?version= >=1.4.0.0,<2.0.0.0
+  - plugin:kubernetes-plugin?version= >=3.3.0.0,<4.0.0.0
+  - top_level/inputs.yaml
+  - top_level/inputs_hidden.yaml
+  - top_level/outputs.yaml
+  - application/00_namespace_and_secrets.yaml
+  - application/01_ingress_nginx.yaml
+  - application/02_jfrog_platform.yaml
+
+labels:
+  csys-obj-type:
+    values:
+      - environment
+  solution:
+    values:
+      - jfrog-platform
+
+blueprint_labels:
+  obj-type:
+    values:
+      - helm
+  csys-obj-type:
+    values:
+      - environment

--- a/JFrog-dell-blueprints/blueprints/jfrog-platform/top_level/inputs.yaml
+++ b/JFrog-dell-blueprints/blueprints/jfrog-platform/top_level/inputs.yaml
@@ -1,0 +1,531 @@
+# Copyright (c) 2026 JFrog Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+---
+
+input_groups:
+  credentials:
+    display_label: Credentials
+    collapsible: true
+    index: 0
+    inputs:
+      - k8s_credentials
+  infrastructure:
+    display_label: Infrastructure
+    collapsible: true
+    index: 1
+    inputs:
+      - namespace
+  persistence:
+    display_label: Persistence
+    collapsible: true
+    index: 2
+    inputs:
+      - persistence
+      - persistence_type
+      - filesystem_cache_enabled
+      - storage_class
+      - pvc_access_mode
+      - pvc_size
+      - nfs_ip
+      - nfs_capacity
+  database:
+    display_label: Database Configuration
+    collapsible: true
+    index: 3
+    inputs:
+      - postgresql_enabled
+      - create_bundled_db_secret
+      - create_external_db_secret
+      - database_admin_password
+      - database_host
+      - database_port
+      - database_ssl_mode
+      - database_user
+      - database_password
+  chart_settings:
+    display_label: Chart Settings
+    collapsible: true
+    index: 4
+    inputs:
+      - release_name
+      - chart_version
+      - sizing_template
+      - ingress_nginx_version
+  licensing:
+    display_label: Licensing
+    collapsible: true
+    index: 5
+    inputs:
+      - create_license_secret
+      - license_secret_ref
+  networking:
+    display_label: Networking
+    collapsible: true
+    index: 6
+    inputs:
+      - nginx_enabled
+      - ingress_enabled
+      - install_ingress_controller
+      - ingress_class_name
+      - ingress_host
+
+inputs:
+
+  k8s_credentials:
+    type: secret_key
+    hidden: false
+    allow_update: false
+    required: true
+    display_label: Kubernetes Credentials Secret
+    description: Name of the DAP secret storing Kubernetes credentials (ssl_ca_cert, token).
+    constraints:
+      - type: k8s
+        error_message: Secret must be of type k8s (Kubernetes credentials).
+    display:
+      group: credentials
+      index: 0
+
+  persistence:
+    type: string
+    hidden: false
+    allow_update: true
+    required: true
+    display_label: Persistence
+    description: >-
+      storage_type: Select a persistence type (file-system or nfs).
+      storage_class: PVC-backed storage using a Kubernetes StorageClass.
+    default: storage_class
+    constraints:
+      - valid_values:
+          - storage_type
+          - storage_class
+        error_message: Must be storage_type or storage_class.
+    display:
+      group: persistence
+      index: 0
+
+  persistence_type:
+    type: string
+    hidden: false
+    allow_update: true
+    required: false
+    display_label: Persistence Type
+    description: >-
+      file-system: local or PVC-backed file storage.
+      nfs: external NFS server mount.
+    default: file-system
+    only_with:
+      persistence: storage_type
+    constraints:
+      - valid_values:
+          - file-system
+          - nfs
+        error_message: Must be file-system or nfs.
+    display:
+      group: persistence
+      index: 1
+
+  filesystem_cache_enabled:
+    type: string
+    hidden: false
+    allow_update: true
+    required: false
+    display_label: File-System Cache Enabled
+    description: Enable Artifactory's local file-system cache layer.
+    default: "false"
+    only_with:
+      persistence: storage_type
+      persistence_type: file-system
+    constraints:
+      - valid_values:
+          - "true"
+          - "false"
+        error_message: Must be true or false.
+    display:
+      group: persistence
+      index: 2
+
+  storage_class:
+    type: string
+    hidden: false
+    allow_update: false
+    required: false
+    display_label: Storage Class
+    description: Kubernetes StorageClass name for persistent volumes. Leave empty to use cluster default.
+    default: ""
+    only_with:
+      persistence: storage_class
+    constraints:
+      - pattern: '^$|^[a-z0-9][a-z0-9\-]*$'
+        error_message: Must be empty or a valid StorageClass name.
+    display:
+      group: persistence
+      index: 3
+
+  pvc_access_mode:
+    type: string
+    hidden: false
+    allow_update: false
+    required: false
+    display_label: PVC Access Mode
+    description: Access mode for the PersistentVolumeClaim.
+    default: ReadWriteOnce
+    only_with:
+      persistence: storage_class
+    constraints:
+      - valid_values:
+          - ReadWriteOnce
+          - ReadWriteMany
+          - ReadOnlyMany
+        error_message: Must be ReadWriteOnce, ReadWriteMany, or ReadOnlyMany.
+    display:
+      group: persistence
+      index: 4
+
+  pvc_size:
+    type: string
+    hidden: false
+    allow_update: false
+    required: false
+    display_label: PVC Size
+    description: Storage default size. Should be increased for production deployments.
+    default: "20Gi"
+    only_with:
+      persistence: storage_class
+    constraints:
+      - pattern: '^[0-9]+(Gi|Ti|Mi|G|T|M)$'
+        error_message: Must be a valid Kubernetes storage size (e.g., 20Gi, 100Gi).
+    display:
+      group: persistence
+      index: 5
+
+  nfs_ip:
+    type: string
+    hidden: false
+    allow_update: true
+    required: false
+    display_label: NFS Server IP
+    description: IP address of the external NFS server.
+    default: ""
+    only_with:
+      persistence: storage_type
+      persistence_type: nfs
+    constraints:
+      - pattern: '^$|^(\d{1,3}\.){3}\d{1,3}$'
+        error_message: Must be empty or a valid IPv4 address.
+    display:
+      group: persistence
+      index: 6
+
+  nfs_capacity:
+    type: string
+    hidden: false
+    allow_update: true
+    required: false
+    display_label: NFS Capacity
+    description: Storage capacity for NFS mount (e.g., 200Gi).
+    default: "200Gi"
+    only_with:
+      persistence: storage_type
+      persistence_type: nfs
+    constraints:
+      - pattern: '^[0-9]+(Gi|Ti|Mi|G|T|M)$'
+        error_message: Must be a valid Kubernetes storage capacity (e.g., 200Gi, 1Ti).
+    display:
+      group: persistence
+      index: 7
+
+  postgresql_enabled:
+    type: string
+    hidden: false
+    allow_update: true
+    required: true
+    display_label: Bundled PostgreSQL
+    description: >-
+      When true, the bundled PostgreSQL subchart is deployed. Set to false
+      to connect to an external PostgreSQL instance.
+    default: "true"
+    constraints:
+      - valid_values:
+          - "true"
+          - "false"
+        error_message: Must be true or false.
+    display:
+      group: database
+      index: 0
+
+  create_bundled_db_secret:
+    type: integer
+    hidden: false
+    allow_update: false
+    required: false
+    display_label: Create Bundled Database Secret
+    description: >-
+      Create a K8s secret with default bundled PostgreSQL credentials
+      (postgres / artifactory / artifactory). 0 = No, 1 = Yes.
+    default: 0
+    only_with:
+      postgresql_enabled: "true"
+    constraints:
+      - valid_values: [0, 1]
+        error_message: Must be 0 (skip) or 1 (create).
+    display:
+      group: database
+      index: 1
+
+  create_external_db_secret:
+    type: integer
+    hidden: false
+    allow_update: false
+    required: false
+    display_label: Create External Database Secret
+    description: >-
+      Create a K8s secret with credentials from DAP secrets below.
+      0 = No, 1 = Yes.
+    default: 0
+    only_with:
+      postgresql_enabled: "false"
+    constraints:
+      - valid_values: [0, 1]
+        error_message: Must be 0 (skip) or 1 (create).
+    display:
+      group: database
+      index: 2
+
+  database_admin_password:
+    type: secret_key
+    hidden: false
+    allow_update: false
+    required: true
+    display_label: Database Admin Password
+    description: >-
+      DAP general secret holding the PostgreSQL admin (superuser) password.
+      Used by the init container to create product databases.
+    only_with:
+      postgresql_enabled: "false"
+    constraints:
+      - type: general
+        error_message: Secret must be of type general.
+    display:
+      group: database
+      index: 3
+
+  database_host:
+    type: string
+    hidden: false
+    allow_update: false
+    required: true
+    display_label: Database Host
+    description: >-
+      Hostname of the PostgreSQL server. Default matches the bundled
+      subchart service name. Override for external databases.
+    default: jfrog-platform-postgresql
+    only_with:
+      postgresql_enabled: "false"
+    constraints:
+      - pattern: '^[a-zA-Z0-9]([a-zA-Z0-9\-\.]*[a-zA-Z0-9])?$'
+        error_message: Must be a valid hostname or IP address.
+    display:
+      group: database
+      index: 4
+
+  database_port:
+    type: string
+    hidden: false
+    allow_update: false
+    required: true
+    display_label: Database Port
+    description: >-
+      Port number of the external PostgreSQL server.
+    default: "5432"
+    only_with:
+      postgresql_enabled: "false"
+    constraints:
+      - pattern: '^\d{1,5}$'
+        error_message: Must be a valid port number (1-65535).
+    display:
+      group: database
+      index: 5
+
+  database_ssl_mode:
+    type: string
+    hidden: false
+    allow_update: false
+    required: true
+    display_label: Database SSL Mode
+    description: >-
+      PostgreSQL SSL connection mode. Use require or verify-full for
+      external production databases.
+    default: disable
+    only_with:
+      postgresql_enabled: "false"
+    constraints:
+      - valid_values:
+          - disable
+          - require
+          - verify-ca
+          - verify-full
+        error_message: Must be disable, require, verify-ca, or verify-full.
+    display:
+      group: database
+      index: 6
+
+  database_user:
+    type: secret_key
+    hidden: false
+    allow_update: false
+    required: true
+    display_label: Database User
+    description: >-
+      DAP general secret holding the Artifactory PostgreSQL database username.
+    only_with:
+      postgresql_enabled: "false"
+    constraints:
+      - type: general
+        error_message: Secret must be of type general.
+    display:
+      group: database
+      index: 7
+
+  database_password:
+    type: secret_key
+    hidden: false
+    allow_update: false
+    required: true
+    display_label: Database Password
+    description: >-
+      DAP general secret holding the Artifactory PostgreSQL database password.
+    only_with:
+      postgresql_enabled: "false"
+    constraints:
+      - type: general
+        error_message: Secret must be of type general.
+    display:
+      group: database
+      index: 8
+
+  sizing_template:
+    type: string
+    hidden: false
+    allow_update: true
+    required: true
+    display_label: Sizing Template
+    description: >
+      Resource sizing profile for all JFrog Platform components.
+      xsmall - 1 replica, 1 CPU / 4 Gi (dev/test, minimum).
+      small - 1 replica, 1 CPU / 5 Gi (small teams, up to ~50 users).
+      medium - 2 replicas, 1 CPU / 5 Gi each (HA, up to ~500 users).
+      large - 3 replicas, 2 CPU / 12 Gi each (large orgs, up to ~2000 users).
+      xlarge - 4 replicas, 2 CPU / 16 Gi each (very large orgs, up to ~5000 users).
+      2xlarge - 6 replicas, 4 CPU / 24 Gi each (enterprise-scale, 5000+ users).
+    default: small
+    constraints:
+      - valid_values:
+          - xsmall
+          - small
+          - medium
+          - large
+          - xlarge
+          - 2xlarge
+        error_message: Must be one of xsmall, small, medium, large, xlarge, 2xlarge.
+    display:
+      group: chart_settings
+      index: 2
+
+  create_license_secret:
+    type: integer
+    hidden: false
+    allow_update: false
+    required: false
+    display_label: Create License Secret
+    description: >-
+      Create a Kubernetes Secret with the Artifactory license from a DAP
+      general secret. 0 = No (trial mode), 1 = Yes. When set to 0,
+      Artifactory starts in trial mode and the license can be applied
+      later via the UI.
+    default: 0
+    constraints:
+      - valid_values: [0, 1]
+        error_message: Must be 0 (skip) or 1 (create).
+    display:
+      group: licensing
+      index: 0
+
+  license_secret_ref:
+    type: secret_key
+    hidden: false
+    allow_update: true
+    required: false
+    display_label: License Secret
+    description: >-
+      DAP general secret containing the raw Artifactory license text.
+      Store the license key content as-is in the secret value.
+      For HA, store the full multi-license file content.
+      Required only when Create License Secret is set to 1.
+    constraints:
+      - type: general
+        error_message: Secret must be of type general.
+    display:
+      group: licensing
+      index: 1
+
+  install_ingress_controller:
+    type: integer
+    hidden: false
+    allow_update: true
+    required: false
+    display_label: Install Ingress Controller
+    description: >-
+      Install an ingress-nginx controller on the cluster before deploying
+      Artifactory. 0 = No, 1 = Yes.
+    default: 0
+    only_with:
+      nginx_enabled: "false"
+      ingress_enabled: "true"
+    constraints:
+      - valid_values: [0, 1]
+        error_message: Must be 0 (skip) or 1 (install).
+    display:
+      group: networking
+      index: 2
+
+  ingress_class_name:
+    type: string
+    hidden: false
+    allow_update: true
+    required: false
+    display_label: "Ingress Class Name"
+    description: >-
+      Name of an existing Kubernetes IngressClass to bind the Artifactory Ingress to.
+      Examples: nginx, istio, haproxy.
+    default: nginx
+    only_with:
+      nginx_enabled: "false"
+      ingress_enabled: "true"
+    constraints:
+      - pattern: '^[a-z0-9][a-z0-9\-\.]*$'
+        error_message: Must be a valid ingress class name.
+    display:
+      group: networking
+      index: 3
+
+  ingress_host:
+    type: string
+    hidden: false
+    allow_update: true
+    required: false
+    display_label: "Ingress Host"
+    description: >-
+      DNS hostname for the Ingress resource (e.g., artifactory.example.com).
+    default: "artifactory.example.com"
+    only_with:
+      nginx_enabled: "false"
+      ingress_enabled: "true"
+    constraints:
+      - pattern: '^$|^[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)+$'
+        error_message: Must be empty or a valid DNS hostname (e.g., artifactory.example.com).
+    display:
+      group: networking
+      index: 4

--- a/JFrog-dell-blueprints/blueprints/jfrog-platform/top_level/inputs_hidden.yaml
+++ b/JFrog-dell-blueprints/blueprints/jfrog-platform/top_level/inputs_hidden.yaml
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 JFrog Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+---
+
+inputs:
+
+  namespace:
+    type: string
+    hidden: false
+    allow_update: false
+    required: true
+    display_label: Kubernetes Namespace
+    description: Target namespace for JFrog Platform (created if it does not exist).
+    default: jfrog-platform
+    constraints:
+      - pattern: '^[a-z0-9][a-z0-9\-]{0,62}$'
+        error_message: Must be a valid Kubernetes namespace name.
+    display:
+      group: infrastructure
+      index: 0
+
+  release_name:
+    type: string
+    hidden: false
+    allow_update: false
+    required: true
+    display_label: Helm Release Name
+    description: Name of the Helm release for this deployment. Fixed at build time.
+    default: jfrog-platform
+    constraints:
+      - pattern: '^[a-z0-9][a-z0-9\-]{0,52}$'
+        error_message: Must be a valid Helm release name.
+    display:
+      group: chart_settings
+      index: 0
+
+  chart_version:
+    type: string
+    hidden: false
+    allow_update: false
+    required: true
+    display_label: Chart Version
+    description: Version of the jfrog/jfrog-platform Helm chart. Injected automatically during release packaging.
+    default: 0.0.0
+    constraints:
+      - pattern: '^\d+\.\d+\.\d+$'
+        error_message: Must be a valid semantic version.
+    display:
+      group: chart_settings
+      index: 1
+
+  ingress_nginx_version:
+    type: string
+    hidden: true
+    allow_update: false
+    required: true
+    display_label: Ingress NGINX Chart Version
+    description: Version of the ingress-nginx Helm chart. Pinned at build time for reproducibility.
+    default: 4.12.1
+    constraints:
+      - pattern: '^\d+\.\d+\.\d+$'
+        error_message: Must be a valid semantic version.
+    display:
+      group: chart_settings
+      index: 3
+
+  nginx_enabled:
+    type: string
+    hidden: false
+    allow_update: true
+    required: true
+    display_label: Bundled NGINX (LoadBalancer)
+    description: >-
+      Enable the chart's bundled NGINX reverse-proxy with a LoadBalancer service.
+      Set to true for LoadBalancer mode. Set to false to use Kubernetes Ingress instead.
+    default: "true"
+    constraints:
+      - valid_values: ["true", "false"]
+        error_message: Must be true or false.
+    display:
+      group: networking
+      index: 0
+
+  ingress_enabled:
+    type: string
+    hidden: false
+    allow_update: true
+    required: true
+    display_label: Kubernetes Ingress
+    description: >-
+      Enable a Kubernetes Ingress resource for external access.
+      Set to true when Bundled NGINX is false.
+    default: "false"
+    only_with:
+      nginx_enabled: "false"
+    constraints:
+      - valid_values: ["true", "false"]
+        error_message: Must be true or false.
+    display:
+      group: networking
+      index: 1
+

--- a/JFrog-dell-blueprints/blueprints/jfrog-platform/top_level/outputs.yaml
+++ b/JFrog-dell-blueprints/blueprints/jfrog-platform/top_level/outputs.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 JFrog Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+---
+
+capabilities:
+  release_name:
+    description: Name of the deployed Helm release
+    value: { get_input: release_name }
+
+  namespace:
+    description: Kubernetes namespace of the deployment
+    value: { get_input: namespace }
+
+  sizing:
+    description: Applied sizing template
+    value: { get_input: sizing_template }
+
+  platform_url_ingress:
+    description: Artifactory URL when using ingress deployment mode.
+    value:
+      concat:
+        - "http://"
+        - { get_input: ingress_host }
+        - "/artifactory"
+
+  platform_url_command:
+    description: >-
+      Run this command to get the Artifactory external IP when using
+      nginx/LoadBalancer deployment mode.
+    value:
+      concat:
+        - "kubectl get svc "
+        - { get_input: release_name }
+        - "-artifactory-nginx -n "
+        - { get_input: namespace }
+        - " -o jsonpath='{.status.loadBalancer.ingress[0].ip}'"

--- a/JFrog-dell-blueprints/examples/bundled-postgres-licensed.yaml
+++ b/JFrog-dell-blueprints/examples/bundled-postgres-licensed.yaml
@@ -1,0 +1,41 @@
+# Example: Bundled PostgreSQL + Licensed
+#
+# Same as the default but with a license applied at deploy time.
+# The license is stored in a DAP general secret and written to a
+# Kubernetes Secret before Helm install.
+#
+# Prerequisites:
+#   1. Create a DAP general secret (e.g., "artifactory-license") containing
+#      the raw Artifactory license text.  Paste the full license content
+#      starting with "products:" — do NOT base64-encode it.
+#
+# DAP UI steps:
+#   1. Credentials       → select your Kubernetes credentials secret
+#   2. Database           → set Create Bundled Database Secret to 1
+#   3. Licensing          → set Create License Secret to 1
+#                         → select the license secret from the dropdown
+#   4. Leave other groups at defaults
+#   5. Click Deploy
+
+inputs:
+
+  # ── Credentials (required) ───────────────────────────────────────
+  k8s_credentials: my-k8s-secret
+
+  # ── Infrastructure ───────────────────────────────────────────────
+  namespace: jfrog-platform
+
+  # ── Database ─────────────────────────────────────────────────────
+  postgresql_enabled: "true"
+  create_bundled_db_secret: 1                 # Yes — create K8s secret with bundled defaults
+
+  # ── Licensing ────────────────────────────────────────────────────
+  create_license_secret: 1                # Yes — create K8s Secret with license
+  license_secret_ref: artifactory-license # DAP general secret name
+
+  # ── Chart Settings ──────────────────────────────────────────────
+  release_name: jfrog-platform
+  sizing_template: small
+
+  # ── Networking ──────────────────────────────────────────────────
+  nginx_enabled: "true"

--- a/JFrog-dell-blueprints/examples/bundled-postgres-trial.yaml
+++ b/JFrog-dell-blueprints/examples/bundled-postgres-trial.yaml
@@ -1,0 +1,44 @@
+# Example: Bundled PostgreSQL + Trial License (Default)
+#
+# Simplest deployment — uses the bundled PostgreSQL subchart and starts
+# Artifactory in trial mode.  Only the k8s credentials secret is required.
+#
+# Prerequisites:
+#   1. A DAP Kubernetes credentials secret (type: k8s).
+#
+# DAP UI steps:
+#   1. Credentials group  → select your Kubernetes credentials secret
+#   2. Database            → set Create Bundled Database Secret to 1
+#   3. Leave all other groups at their defaults
+#   4. Click Deploy
+#
+# What happens behind the scenes:
+#   - postgresql_enabled = "true"  →  bundled PostgreSQL subchart is deployed
+#   - create_bundled_db_secret = 1     →  K8s Secret "jfrog-platform-database-creds"
+#                                      created with bundled defaults
+#                                      (postgres / artifactory / artifactory)
+#   - create_license_secret = 0   →  no license K8s Secret, Artifactory
+#                                      starts in trial mode
+#   - Namespace "jfrog-platform" created before Helm install
+
+inputs:
+
+  # ── Credentials (required) ───────────────────────────────────────
+  k8s_credentials: my-k8s-secret          # DAP secret name (type: k8s)
+
+  # ── Infrastructure ───────────────────────────────────────────────
+  namespace: jfrog-platform               # default
+
+  # ── Database ─────────────────────────────────────────────────────
+  postgresql_enabled: "true"              # default — bundled PostgreSQL
+  create_bundled_db_secret: 1                 # Yes — create K8s secret with bundled defaults
+
+  # ── Licensing ────────────────────────────────────────────────────
+  create_license_secret: 0                # No — trial mode
+
+  # ── Chart Settings ──────────────────────────────────────────────
+  release_name: jfrog-platform            # default
+  sizing_template: small                  # default
+
+  # ── Networking ──────────────────────────────────────────────────
+  nginx_enabled: "true"                   # default — LoadBalancer

--- a/JFrog-dell-blueprints/examples/external-postgres-licensed.yaml
+++ b/JFrog-dell-blueprints/examples/external-postgres-licensed.yaml
@@ -1,0 +1,64 @@
+# Example: External PostgreSQL + Licensed
+#
+# Production-style deployment connecting to an external PostgreSQL
+# instance with credentials stored as DAP general secrets.
+#
+# Prerequisites:
+#   1. An external PostgreSQL server accessible from the K8s cluster.
+#   2. Create these DAP general secrets:
+#      - "pg-admin-password"   → PostgreSQL superuser password
+#      - "pg-artif-user"       → Artifactory database username (e.g., "artifactory")
+#      - "pg-artif-password"   → Artifactory database password
+#      - "artifactory-license" → raw Artifactory license text
+#   3. Pre-create the "artifactory" database on the external PostgreSQL
+#      server (initDBCreation is automatically set to false when
+#      postgresql_enabled is false).
+#
+# DAP UI steps:
+#   1. Credentials       → select your Kubernetes credentials secret
+#   2. Database           → set Bundled PostgreSQL to "false"
+#                         → set Create External Database Secret to 1
+#                         → fill in Database Host, Port, SSL Mode
+#                         → select DAP secrets for Admin Password, User, Password
+#   3. Licensing          → set Create License Secret to 1
+#                         → select the license secret
+#   4. Chart Settings     → pick sizing template for your org size
+#   5. Click Deploy
+#
+# What happens behind the scenes:
+#   - postgresql_enabled = "false"  →  bundled PostgreSQL disabled
+#   - create_external_db_secret = 1     →  K8s Secret "jfrog-platform-database-creds"
+#                                      created with values from DAP secrets
+#   - JDBC URL constructed via concat:
+#       jdbc:postgresql://pg.example.com:5432/artifactory?sslmode=require
+#   - Helm chart reads credentials from the K8s Secret via
+#       database.secrets.*.name / database.secrets.*.key
+
+inputs:
+
+  # ── Credentials (required) ───────────────────────────────────────
+  k8s_credentials: my-k8s-secret
+
+  # ── Infrastructure ───────────────────────────────────────────────
+  namespace: jfrog-platform
+
+  # ── Database (external) ─────────────────────────────────────────
+  postgresql_enabled: "false"
+  create_external_db_secret: 1                # Yes — create K8s secret from DAP secrets
+  database_host: pg.example.com
+  database_port: "5432"
+  database_ssl_mode: require
+  database_admin_password: pg-admin-password    # DAP general secret name
+  database_user: pg-artif-user                  # DAP general secret name
+  database_password: pg-artif-password          # DAP general secret name
+
+  # ── Licensing ────────────────────────────────────────────────────
+  create_license_secret: 1                # Yes — create K8s Secret with license
+  license_secret_ref: artifactory-license
+
+  # ── Chart Settings ──────────────────────────────────────────────
+  release_name: jfrog-platform
+  sizing_template: medium
+
+  # ── Networking ──────────────────────────────────────────────────
+  nginx_enabled: "true"

--- a/JFrog-dell-blueprints/examples/ha-production.yaml
+++ b/JFrog-dell-blueprints/examples/ha-production.yaml
@@ -1,0 +1,73 @@
+# Example: HA Production Deployment
+#
+# Full production setup with:
+#   - External PostgreSQL
+#   - Enterprise HA license (multiple keys for multiple replicas)
+#   - Large sizing template (3 Artifactory replicas)
+#   - Kubernetes Ingress with TLS
+#   - PVC-backed persistence with a specific StorageClass
+#
+# Prerequisites:
+#   1. External PostgreSQL with pre-created "artifactory" database.
+#   2. DAP general secrets for database credentials (3 secrets).
+#   3. DAP general secret with the HA license file containing one
+#      license key per Artifactory replica.
+#   4. An ingress controller on the cluster.
+#   5. DNS + TLS certificate for the ingress hostname.
+#   6. A StorageClass that supports ReadWriteOnce (e.g., gp3, managed-csi).
+#
+# DAP UI steps:
+#   1. Credentials       → select Kubernetes credentials secret
+#   2. Persistence        → select storage_class mode
+#                         → set Storage Class (e.g., gp3)
+#                         → set PVC Size (e.g., 200Gi)
+#   3. Database           → set Bundled PostgreSQL to "false"
+#                         → set Create External Database Secret to 1
+#                         → fill in external DB connection details
+#                         → select DAP secrets for credentials
+#   4. Chart Settings     → set Sizing Template to "large"
+#   5. Licensing          → set Create License Secret to 1
+#                         → select the HA license secret
+#   6. Networking         → set Bundled NGINX to "false"
+#                         → set Kubernetes Ingress to "true"
+#                         → set Ingress Host
+#   7. Click Deploy
+
+inputs:
+
+  # ── Credentials (required) ───────────────────────────────────────
+  k8s_credentials: prod-k8s-secret
+
+  # ── Infrastructure ───────────────────────────────────────────────
+  namespace: jfrog-platform
+
+  # ── Persistence (PVC) ──────────────────────────────────────────
+  persistence: storage_class
+  storage_class: gp3
+  pvc_access_mode: ReadWriteOnce
+  pvc_size: "200Gi"
+
+  # ── Database (external) ─────────────────────────────────────────
+  postgresql_enabled: "false"
+  create_external_db_secret: 1                # Yes — create K8s secret from DAP secrets
+  database_host: pg-primary.prod.internal
+  database_port: "5432"
+  database_ssl_mode: verify-full
+  database_admin_password: prod-pg-admin-password
+  database_user: prod-pg-artif-user
+  database_password: prod-pg-artif-password
+
+  # ── Chart Settings ──────────────────────────────────────────────
+  release_name: jfrog-platform
+  sizing_template: large
+
+  # ── Licensing ────────────────────────────────────────────────────
+  create_license_secret: 1                # Yes — create K8s Secret with license
+  license_secret_ref: prod-artifactory-ha-license
+
+  # ── Networking (Ingress) ────────────────────────────────────────
+  nginx_enabled: "false"
+  ingress_enabled: "true"
+  install_ingress_controller: 0           # No — already have one in prod
+  ingress_class_name: nginx
+  ingress_host: artifactory.prod.example.com

--- a/JFrog-dell-blueprints/examples/ingress-mode.yaml
+++ b/JFrog-dell-blueprints/examples/ingress-mode.yaml
@@ -1,0 +1,60 @@
+# Example: Kubernetes Ingress Mode (no bundled NGINX)
+#
+# Exposes Artifactory via a Kubernetes Ingress resource instead of
+# the bundled NGINX LoadBalancer.  Optionally installs the ingress-nginx
+# controller if one is not already present on the cluster.
+#
+# Prerequisites:
+#   1. An ingress controller on the cluster, OR set
+#      install_ingress_controller to 1 to deploy ingress-nginx.
+#   2. DNS record pointing ingress_host to the ingress controller's
+#      external IP/LB.
+#
+# DAP UI steps:
+#   1. Credentials       → select your Kubernetes credentials secret
+#   2. Database           → set Create Bundled Database Secret to 1
+#   3. Networking         → set Bundled NGINX to "false"
+#                         → set Kubernetes Ingress to "true"
+#                         → set Install Ingress Controller to 1
+#                            (or 0 if you already have one)
+#                         → set Ingress Class Name (e.g., nginx)
+#                         → set Ingress Host (e.g., artifactory.example.com)
+#   4. Leave other groups at defaults (or configure license as needed)
+#   5. Click Deploy
+#
+# What happens behind the scenes:
+#   - postgresql_enabled = "true"    →  bundled PostgreSQL deployed
+#   - create_bundled_db_secret = 1       →  K8s Secret "jfrog-platform-database-creds"
+#                                       created with bundled defaults
+#   - nginx_enabled = "false"        →  bundled NGINX disabled
+#   - ingress_enabled = "true"       →  K8s Ingress resource created
+#   - install_ingress_controller = 1 →  ingress-nginx Helm chart installed
+#                                       in the ingress-nginx namespace
+#   - The JFrog Platform chart creates an Ingress resource bound to the
+#     specified class with the given hostname
+
+inputs:
+
+  # ── Credentials (required) ───────────────────────────────────────
+  k8s_credentials: my-k8s-secret
+
+  # ── Infrastructure ───────────────────────────────────────────────
+  namespace: jfrog-platform
+
+  # ── Database ─────────────────────────────────────────────────────
+  postgresql_enabled: "true"
+  create_bundled_db_secret: 1                 # Yes — create K8s secret with bundled defaults
+
+  # ── Licensing ────────────────────────────────────────────────────
+  create_license_secret: 0                # No — trial mode
+
+  # ── Chart Settings ──────────────────────────────────────────────
+  release_name: jfrog-platform
+  sizing_template: small
+
+  # ── Networking (Ingress mode) ───────────────────────────────────
+  nginx_enabled: "false"
+  ingress_enabled: "true"
+  install_ingress_controller: 1           # Yes — deploy ingress-nginx
+  ingress_class_name: nginx
+  ingress_host: artifactory.example.com

--- a/JFrog-dell-blueprints/scripts/get_latest_jfrog_platform_version.sh
+++ b/JFrog-dell-blueprints/scripts/get_latest_jfrog_platform_version.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Fetch the latest stable version of the JFrog Platform Helm chart.
+# Requires: curl, grep, sort, head (no Helm CLI needed).
+
+set -euo pipefail
+
+REPO_INDEX_URL="https://charts.jfrog.io/index.yaml"
+
+# Fetches the latest stable chart version from the JFrog Helm repo index.
+# The index lists entries newest-first; we match the first .tgz URL for
+# the target chart to extract the version without needing yq or Helm CLI.
+get_latest_chart_version() {
+  local chart_name="$1"
+  curl -sL "$REPO_INDEX_URL" 2>/dev/null \
+    | grep -oE "${chart_name}-[0-9]+\.[0-9]+\.[0-9]+\.tgz" \
+    | head -1 \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
+}
+
+CHARTS=(
+  "jfrog-platform"
+)
+
+echo "--- Latest Stable JFrog Platform Helm Chart Version ---"
+echo ""
+
+for chart in "${CHARTS[@]}"; do
+  version=$(get_latest_chart_version "$chart")
+  if [[ -n "$version" ]]; then
+    echo "  JFrog Platform Helm chart (${chart}): ${version}"
+  else
+    echo "  JFrog Platform Helm chart (${chart}): (unable to fetch)"
+  fi
+done
+
+echo ""
+echo "Pass this as the 'chart_version' input when deploying the blueprint."

--- a/JFrog-dell-blueprints/scripts/merge_nginx_config.py
+++ b/JFrog-dell-blueprints/scripts/merge_nginx_config.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 JFrog Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+"""Merge nginx mainConf into sizing templates at build time.
+
+Reads the raw nginx.conf content and inserts it as nginx.mainConf
+under the existing artifactory.nginx block in each sizing template.
+Source sizing templates are not modified — only staged copies.
+
+Usage: merge_nginx_config.py <nginx-main-conf.txt> <sizing-dir>
+"""
+import sys
+import os
+import glob
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <nginx-main-conf.txt> <sizing-dir>", file=sys.stderr)
+        sys.exit(1)
+
+    nginx_file = sys.argv[1]
+    sizing_dir = sys.argv[2]
+
+    with open(nginx_file) as f:
+        nginx_conf = f.read().rstrip()
+
+    if not nginx_conf:
+        print(f"ERROR: Empty nginx conf in {nginx_file}", file=sys.stderr)
+        sys.exit(1)
+
+    mainconf_block = "    mainConf: |\n"
+    for line in nginx_conf.split("\n"):
+        mainconf_block += f"      {line}\n"
+
+    for path in sorted(glob.glob(os.path.join(sizing_dir, "platform-*.yaml"))):
+        with open(path) as f:
+            content = f.read()
+
+        marker = "\n  nginx:\n"
+        if marker not in content:
+            print(
+                f"  WARNING: 'nginx:' block not found in {os.path.basename(path)}",
+                file=sys.stderr,
+            )
+            continue
+
+        idx = content.index(marker) + len(marker)
+        content = content[:idx] + mainconf_block + content[idx:]
+
+        with open(path, "w") as f:
+            f.write(content)
+        print(f"  Merged mainConf into {os.path.basename(path)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/JFrog-dell-blueprints/scripts/release.sh
+++ b/JFrog-dell-blueprints/scripts/release.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# Create a new Git release branch and tag for a JFrog Dell Blueprint,
+# triggering the GitHub Actions workflow that builds the zip artifact.
+
+set -euo pipefail
+
+# ── Non-interactive mode ─────────────────────────────────────────────
+ASSUME_YES=${ASSUME_YES:-0}
+if [[ "${1:-}" == "-y" ]]; then
+  ASSUME_YES=1
+  shift || true
+fi
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+confirm() {
+  local prompt="$1"
+  if [[ "$ASSUME_YES" == "1" ]]; then
+    echo "$prompt (auto-yes)"
+    return 0
+  fi
+  echo ""
+  read -p "$prompt (y/n) " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Operation cancelled."
+    exit 0
+  fi
+}
+
+detect_default_branch() {
+  git remote show origin 2>/dev/null | sed -n '/HEAD branch/s/.*: //p'
+}
+
+ensure_clean_worktree() {
+  if ! git diff-index --quiet HEAD --; then
+    echo "Your working tree has uncommitted changes."
+    confirm "Proceed anyway?"
+  fi
+}
+
+normalize_version() {
+  local input="$1"
+  if [[ ! "$input" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Version must be SemVer (e.g., 1.2.3 or v1.2.3)." >&2
+    exit 1
+  fi
+  local ver="${input#v}"
+  echo "v${ver}"
+}
+
+TAG_PREFIX="jfrog-dell-blueprints"
+
+tag_exists() {
+  local tag="$1"
+  git fetch --tags >/dev/null 2>&1 || true
+  if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+    return 0
+  fi
+  if git ls-remote --tags origin | grep -q "refs/tags/$tag$"; then
+    return 0
+  fi
+  return 1
+}
+
+get_latest_local_tag() {
+  git tag -l "${TAG_PREFIX}/v*" --sort='-v:refname' | head -n 1
+}
+
+get_latest_chart_version() {
+  local chart_name="$1"
+  local repo_index="https://charts.jfrog.io/index.yaml"
+  curl -sL "$repo_index" 2>/dev/null \
+    | grep -oE "${chart_name}-[0-9]+\.[0-9]+\.[0-9]+\.tgz" \
+    | head -1 \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
+}
+
+# ── Blueprint catalogue ─────────────────────────────────────────────
+# Each entry is <directory>:<display-name>.
+# Add new blueprints here as they are created.
+BLUEPRINTS=(
+  "blueprints/jfrog-platform:JFrog Dell Blueprint"
+)
+
+# ── Show existing releases ───────────────────────────────────────────
+echo "--- Current JFrog Dell Blueprint Releases ---"
+
+git fetch --tags >/dev/null 2>&1 || true
+LATEST_TAG=$(get_latest_local_tag)
+if [[ -n "$LATEST_TAG" ]]; then
+  echo "Latest tag: ${LATEST_TAG}"
+else
+  echo "No existing version tags found."
+fi
+
+echo ""
+echo "Available blueprints:"
+for entry in "${BLUEPRINTS[@]}"; do
+  IFS=':' read -r dir name <<< "$entry"
+  echo "  - ${name} (${dir}/)"
+done
+
+echo ""
+echo "--- Latest JFrog Platform Helm Chart Version ---"
+LATEST_CHART=$(get_latest_chart_version "jfrog-platform")
+if [[ -n "$LATEST_CHART" ]]; then
+  echo "  JFrog Platform Helm chart: ${LATEST_CHART}"
+else
+  echo "  JFrog Platform Helm chart: (unable to fetch)"
+fi
+
+echo "-------------------------------------"
+echo ""
+
+# ── Select blueprint ─────────────────────────────────────────────────
+if [[ ${#BLUEPRINTS[@]} -eq 1 ]]; then
+  IFS=':' read -r BLUEPRINT_DIR BLUEPRINT_NAME <<< "${BLUEPRINTS[0]}"
+  echo "Using blueprint: ${BLUEPRINT_NAME} (${BLUEPRINT_DIR}/)"
+else
+  echo "Select a blueprint:"
+  select entry in "${BLUEPRINTS[@]}"; do
+    IFS=':' read -r BLUEPRINT_DIR BLUEPRINT_NAME <<< "$entry"
+    break
+  done
+fi
+
+# ── Version input ────────────────────────────────────────────────────
+if [[ -z "${NEW_VERSION:-}" ]]; then
+  read -r -p "Please enter the new version number (e.g., 1.2.3): " NEW_VERSION
+fi
+NEW_VERSION=$(normalize_version "$NEW_VERSION")
+
+# ── Pre-flight checks ───────────────────────────────────────────────
+BRANCH_TO_CHECKOUT="$(detect_default_branch)"
+[[ -z "$BRANCH_TO_CHECKOUT" ]] && BRANCH_TO_CHECKOUT="master"
+
+ensure_clean_worktree
+
+RELEASE_TAG="${TAG_PREFIX}/${NEW_VERSION}"
+
+if tag_exists "$RELEASE_TAG"; then
+  echo "Error: Tag ${RELEASE_TAG} already exists locally or on origin." >&2
+  exit 1
+fi
+
+# Verify the blueprint directory exists
+if [[ ! -d "$BLUEPRINT_DIR" ]]; then
+  echo "Error: Blueprint directory '${BLUEPRINT_DIR}' not found." >&2
+  exit 1
+fi
+
+echo ""
+echo "--- Starting release process for '${BLUEPRINT_NAME}' ${NEW_VERSION} ---"
+echo ""
+
+# ── Git workflow ─────────────────────────────────────────────────────
+
+# 1. Checkout the base branch
+echo "About to checkout branch '${BRANCH_TO_CHECKOUT}'..."
+confirm "Proceed to checkout '${BRANCH_TO_CHECKOUT}'?"
+git checkout "${BRANCH_TO_CHECKOUT}"
+
+# 2. Pull latest
+echo "About to pull latest code from '${BRANCH_TO_CHECKOUT}'..."
+confirm "Proceed to pull from '${BRANCH_TO_CHECKOUT}'?"
+git pull --ff-only
+
+# 3. Create release branch
+RELEASE_BRANCH="jfrog-dell-blueprints/${NEW_VERSION}"
+echo "About to create release branch: ${RELEASE_BRANCH}..."
+confirm "Proceed to create branch '${RELEASE_BRANCH}'?"
+git checkout -b "${RELEASE_BRANCH}"
+
+# 4. Push release branch
+echo "About to push release branch to origin..."
+confirm "Proceed to push branch '${RELEASE_BRANCH}' to origin?"
+git push -u origin "${RELEASE_BRANCH}"
+
+# 5. Create tag
+echo "About to create tag: ${RELEASE_TAG}..."
+confirm "Proceed to create tag '${RELEASE_TAG}'?"
+git tag -a "${RELEASE_TAG}" -m "Release ${NEW_VERSION} – ${BLUEPRINT_NAME}"
+
+# 6. Push tag (triggers the Release Blueprint workflow)
+echo "About to push tag to origin (this triggers the GitHub Actions release)..."
+confirm "Proceed to push tag '${RELEASE_TAG}' to origin?"
+git push origin tag "${RELEASE_TAG}"
+
+echo ""
+echo "--- Release process completed successfully! ---"
+echo ""
+echo "  Blueprint : ${BLUEPRINT_NAME}"
+echo "  Version   : ${NEW_VERSION}"
+echo "  Branch    : ${RELEASE_BRANCH}"
+echo "  Tag       : ${RELEASE_TAG}"
+echo ""
+echo "The GitHub Actions 'Release JFrog Dell Blueprint' workflow will now"
+echo "build the zip artifact and publish the GitHub Release automatically."

--- a/JFrog-dell-blueprints/scripts/sync_networking_modes.sh
+++ b/JFrog-dell-blueprints/scripts/sync_networking_modes.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Build-time generator for the NGINX mainConf override.
+#
+# Extracts nginx-main-conf.yaml from the JFrog Platform Helm chart,
+# overrides worker_processes, and outputs it as artifactory.nginx.mainConf.
+#
+# Output (build artifact, not committed to source):
+#   build/nginx-main-conf.txt  (raw nginx.conf content)
+#
+# Usage:
+#   scripts/sync_networking_modes.sh [chart_version] [worker_processes]
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+BUILD_DIR="build"
+REQUESTED_VERSION="${1:-}"
+WORKER_PROCESSES="${2:-4}"
+
+read -r CHART_VERSION CHART_URL <<EOF
+$(python3 - "$REQUESTED_VERSION" <<'PY'
+import sys
+import urllib.request
+import yaml
+
+requested = sys.argv[1] if len(sys.argv) > 1 else ""
+idx = urllib.request.urlopen("https://charts.jfrog.io/index.yaml", timeout=30).read().decode()
+data = yaml.safe_load(idx)
+entries = data["entries"]["jfrog-platform"]
+
+selected = None
+if requested:
+    requested = requested[1:] if requested.startswith("v") else requested
+    for e in entries:
+        if str(e.get("version", "")) == requested:
+            selected = e
+            break
+    if selected is None:
+        raise SystemExit(f"ERROR: Chart version '{requested}' not found in jfrog-platform index")
+else:
+    selected = entries[0]
+
+print(selected["version"], selected["urls"][0])
+PY
+)
+EOF
+
+echo "Syncing nginx main conf from jfrog-platform chart ${CHART_VERSION}"
+echo "Source: ${CHART_URL}"
+echo "worker_processes override: ${WORKER_PROCESSES}"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+curl -sL "$CHART_URL" -o "$TMP_DIR/chart.tgz"
+
+TAR_PATH="jfrog-platform/charts/artifactory/files/nginx-main-conf.yaml"
+if ! tar -tzf "$TMP_DIR/chart.tgz" "$TAR_PATH" >/dev/null 2>&1; then
+  echo "ERROR: Not found in chart: $TAR_PATH" >&2
+  exit 1
+fi
+tar -xzf "$TMP_DIR/chart.tgz" -C "$TMP_DIR" "$TAR_PATH"
+
+SRC="$TMP_DIR/$TAR_PATH"
+sed -i.bak -E "s/^worker_processes[[:space:]]+[^;]+;/worker_processes  ${WORKER_PROCESSES};/" "$SRC"
+rm -f "${SRC}.bak"
+
+# Strip Go template whitespace trim modifiers ({{- and -}}) so that
+# rendered nginx.conf preserves newlines between directives.
+sed -i.bak -E 's/\{\{-/\{\{/g; s/-\}\}/\}\}/g' "$SRC"
+rm -f "${SRC}.bak"
+
+mkdir -p "$BUILD_DIR"
+
+cp "$SRC" "$BUILD_DIR/nginx-main-conf.txt"
+
+echo "Wrote: $BUILD_DIR/nginx-main-conf.txt (synced from chart ${CHART_VERSION})"

--- a/JFrog-dell-blueprints/scripts/sync_sizing_templates.sh
+++ b/JFrog-dell-blueprints/scripts/sync_sizing_templates.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Download jfrog-platform sizing templates from Helm chart and sync locally.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+SIZING_DIR="target/sizing"
+REQUESTED_VERSION="${1:-}"
+
+read -r CHART_VERSION CHART_URL <<EOF
+$(python3 - "$REQUESTED_VERSION" <<'PY'
+import sys
+import urllib.request
+import yaml
+
+requested = sys.argv[1] if len(sys.argv) > 1 else ""
+idx = urllib.request.urlopen("https://charts.jfrog.io/index.yaml", timeout=30).read().decode()
+data = yaml.safe_load(idx)
+entries = data["entries"]["jfrog-platform"]
+
+selected = None
+if requested:
+    requested = requested[1:] if requested.startswith("v") else requested
+    for e in entries:
+        if str(e.get("version", "")) == requested:
+            selected = e
+            break
+    if selected is None:
+        raise SystemExit(f"ERROR: Chart version '{requested}' not found in jfrog-platform index")
+else:
+    selected = entries[0]
+
+print(selected["version"], selected["urls"][0])
+PY
+)
+EOF
+
+echo "Syncing sizing templates from jfrog-platform chart ${CHART_VERSION}"
+echo "Source: ${CHART_URL}"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+curl -sL "$CHART_URL" -o "$TMP_DIR/chart.tgz"
+
+mkdir -p "$SIZING_DIR"
+find "$SIZING_DIR" -mindepth 1 -maxdepth 1 -type f -name 'platform-*.yaml' -delete
+
+for template in platform-xsmall.yaml platform-small.yaml platform-medium.yaml platform-large.yaml platform-xlarge.yaml platform-2xlarge.yaml; do
+  TAR_PATH="jfrog-platform/sizing/${template}"
+  if ! tar -tzf "$TMP_DIR/chart.tgz" "$TAR_PATH" >/dev/null 2>&1; then
+    echo "ERROR: Template not found in chart: $TAR_PATH" >&2
+    exit 1
+  fi
+  tar -xzf "$TMP_DIR/chart.tgz" -C "$TMP_DIR" "$TAR_PATH"
+  cp "$TMP_DIR/$TAR_PATH" "$SIZING_DIR/$template"
+done
+
+echo "Synced sizing templates to: $SIZING_DIR"
+find "$SIZING_DIR" -mindepth 1 -maxdepth 1 -type f -name 'platform-*.yaml' -print | sort | sed 's|.*/|  - |'

--- a/JFrog-dell-blueprints/scripts/validate_blueprints.sh
+++ b/JFrog-dell-blueprints/scripts/validate_blueprints.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+# Validate Dell TOSCA blueprint and changelog files before commit.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+BLUEPRINT_FILES=()
+while IFS= read -r -d '' f; do BLUEPRINT_FILES+=("$f"); done < <(find ./blueprints -type f -name "blueprint.yaml" -print0 2>/dev/null | sort -z)
+CHANGELOG_FILES=()
+while IFS= read -r -d '' f; do CHANGELOG_FILES+=("$f"); done < <(find ./blueprints -type f -name "CHANGELOG.yaml" -print0 2>/dev/null | sort -z)
+
+if [[ ${#BLUEPRINT_FILES[@]} -eq 0 ]]; then
+  echo "No blueprint.yaml files found."
+  exit 0
+fi
+
+if [[ ${#CHANGELOG_FILES[@]} -eq 0 ]]; then
+  echo "No CHANGELOG.yaml files found."
+  exit 1
+fi
+
+python3 - <<'PY'
+import os
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except Exception:
+    print("ERROR: Missing dependency: PyYAML (pip install pyyaml)")
+    sys.exit(1)
+
+root = Path('.').resolve()
+bp_dir = root / 'blueprints'
+blueprints = sorted(bp_dir.rglob('blueprint.yaml')) if bp_dir.is_dir() else []
+changelogs = sorted(bp_dir.rglob('CHANGELOG.yaml')) if bp_dir.is_dir() else []
+
+errors = []
+warnings = []
+
+semver_re = re.compile(r'^\d+\.\d+\.\d+$')
+snake_case_re = re.compile(r'^[a-z][a-z0-9_]*$')
+namespace_re = re.compile(r'^[a-z0-9][a-z0-9\-]{0,62}$')
+k8s_name_re = re.compile(r'^[a-z0-9][a-z0-9\-]*$')
+secret_data_key_re = re.compile(r'^[a-zA-Z0-9._\-]+$')
+
+def rel(p: Path) -> str:
+    return str(p.relative_to(root))
+
+
+def load_yaml(path: Path):
+    try:
+        with path.open() as f:
+            return yaml.safe_load(f)
+    except Exception as e:
+        errors.append(f"{rel(path)}: YAML parse error: {e}")
+        return None
+
+
+def deep_merge(base: dict, overlay: dict) -> dict:
+    """Merge overlay into base, combining dicts and extending lists."""
+    for key, val in overlay.items():
+        if key in base and isinstance(base[key], dict) and isinstance(val, dict):
+            deep_merge(base[key], val)
+        elif key in base and isinstance(base[key], list) and isinstance(val, list):
+            base[key].extend(val)
+        else:
+            base[key] = val
+    return base
+
+
+def resolve_imports(bp_path: Path, data: dict) -> dict:
+    """Follow local YAML imports and merge them into the blueprint data."""
+    imports = data.get('imports', [])
+    if not isinstance(imports, list):
+        return data
+
+    for imp in imports:
+        if not isinstance(imp, str):
+            continue
+        if imp.startswith('dell/') or imp.startswith('plugin:'):
+            continue
+        imp_path = bp_path.parent / imp
+        if imp_path.is_file():
+            imp_data = load_yaml(imp_path)
+            if isinstance(imp_data, dict):
+                deep_merge(data, imp_data)
+    return data
+
+
+def expect(condition, msg):
+    if not condition:
+        errors.append(msg)
+
+
+for bp in blueprints:
+    data = load_yaml(bp)
+    if not isinstance(data, dict):
+        continue
+
+    data = resolve_imports(bp, data)
+
+    expect(data.get('tosca_definitions_version') == 'dell_1_1',
+           f"{rel(bp)}: tosca_definitions_version must be dell_1_1")
+
+    imports = data.get('imports')
+    expect(isinstance(imports, list), f"{rel(bp)}: imports must be a list")
+    if isinstance(imports, list):
+        expect('dell/types/types.yaml' in imports,
+               f"{rel(bp)}: imports must include dell/types/types.yaml")
+
+    inputs = data.get('inputs', {})
+    expect(isinstance(inputs, dict), f"{rel(bp)}: inputs must be a map")
+    if isinstance(inputs, dict):
+        for name, meta in inputs.items():
+            if not snake_case_re.match(name):
+                errors.append(f"{rel(bp)}: input '{name}' must be snake_case")
+            if not isinstance(meta, dict):
+                errors.append(f"{rel(bp)}: input '{name}' must be a map")
+                continue
+            for key in ('type', 'hidden', 'allow_update', 'display_label', 'description'):
+                if key not in meta:
+                    errors.append(f"{rel(bp)}: input '{name}' missing '{key}'")
+
+            constraints = meta.get('constraints', [])
+            input_type = meta.get('type', '')
+            if input_type not in ('dict', 'list') and (not isinstance(constraints, list) or len(constraints) == 0):
+                errors.append(f"{rel(bp)}: input '{name}' must have at least one constraint")
+            else:
+                has_validation_rule = False
+                for c in constraints:
+                    if isinstance(c, dict) and ('pattern' in c or 'valid_values' in c or 'type' in c):
+                        has_validation_rule = True
+                        if 'error_message' not in c:
+                            errors.append(f"{rel(bp)}: input '{name}' constraint missing error_message")
+                if not has_validation_rule:
+                    warnings.append(f"{rel(bp)}: input '{name}' has constraints but no pattern/valid_values/type validation rule")
+
+            if name == 'chart_version':
+                ok = False
+                for c in constraints:
+                    if isinstance(c, dict) and c.get('pattern') == '^\\d+\\.\\d+\\.\\d+$':
+                        ok = True
+                if not ok:
+                    errors.append(f"{rel(bp)}: chart_version must enforce semver pattern ^\\d+\\.\\d+\\.\\d+$")
+
+            if name == 'namespace':
+                ok = False
+                for c in constraints:
+                    if isinstance(c, dict) and c.get('pattern') == '^[a-z0-9][a-z0-9\\-]{0,62}$':
+                        ok = True
+                if not ok:
+                    errors.append(f"{rel(bp)}: namespace should use pattern ^[a-z0-9][a-z0-9\\-]{0,62}$")
+
+            if name.endswith('_secret_name'):
+                ok = False
+                for c in constraints:
+                    if isinstance(c, dict) and c.get('pattern') == '^[a-z0-9][a-z0-9\\-]*$':
+                        ok = True
+                if not ok:
+                    warnings.append(f"{rel(bp)}: {name} should use k8s secret name pattern ^[a-z0-9][a-z0-9\\-]*$")
+
+            if name.endswith('_secret_data_key'):
+                ok = False
+                for c in constraints:
+                    if isinstance(c, dict) and c.get('pattern') == '^[a-zA-Z0-9._\\-]+$':
+                        ok = True
+                if not ok:
+                    errors.append(f"{rel(bp)}: {name} should use secret data key pattern ^[a-zA-Z0-9._\\-]+$")
+
+    groups = data.get('input_groups', {})
+    expect(isinstance(groups, dict), f"{rel(bp)}: input_groups must be a map")
+    if isinstance(groups, dict) and isinstance(inputs, dict):
+        grouped = []
+        group_indexes = []
+        for gname, gmeta in groups.items():
+            if not isinstance(gmeta, dict):
+                errors.append(f"{rel(bp)}: input_groups.{gname} must be a map")
+                continue
+            for req in ('display_label', 'collapsible', 'index', 'inputs'):
+                if req not in gmeta:
+                    errors.append(f"{rel(bp)}: input_groups.{gname} missing '{req}'")
+            if 'index' in gmeta and isinstance(gmeta['index'], int):
+                group_indexes.append(gmeta['index'])
+            ilist = gmeta.get('inputs', [])
+            if isinstance(ilist, list):
+                grouped.extend(ilist)
+
+        missing = sorted(set(inputs.keys()) - set(grouped))
+        unknown = sorted(set(grouped) - set(inputs.keys()))
+        duplicates = sorted({i for i in grouped if grouped.count(i) > 1})
+        if missing:
+            errors.append(f"{rel(bp)}: inputs missing from input_groups: {', '.join(missing)}")
+        if unknown:
+            errors.append(f"{rel(bp)}: input_groups contains unknown inputs: {', '.join(unknown)}")
+        if duplicates:
+            errors.append(f"{rel(bp)}: inputs repeated across groups: {', '.join(duplicates)}")
+
+        if group_indexes:
+            expected = list(range(min(group_indexes), min(group_indexes) + len(group_indexes)))
+            if sorted(group_indexes) != expected:
+                warnings.append(f"{rel(bp)}: input group indexes are not contiguous")
+
+    node_templates = data.get('node_templates', {})
+    if not isinstance(node_templates, dict):
+        errors.append(f"{rel(bp)}: node_templates must be a map")
+    else:
+        has_binary = False
+        has_repo = False
+        has_release = False
+        for _, nmeta in node_templates.items():
+            if not isinstance(nmeta, dict):
+                continue
+            ntype = nmeta.get('type')
+            if ntype == 'dell.nodes.helm.Binary':
+                has_binary = True
+            if ntype == 'dell.nodes.helm.Repo':
+                has_repo = True
+            if ntype == 'dell.nodes.helm.Release':
+                has_release = True
+                props = nmeta.get('properties', {})
+                client = props.get('client_config', {})
+                if not (isinstance(client, dict) and 'get_secret' in client):
+                    errors.append(f"{rel(bp)}: helm release client_config must use get_secret")
+                rcfg = props.get('resource_config', {})
+                flags = rcfg.get('flags', []) if isinstance(rcfg, dict) else []
+                flag_names = [f.get('name') for f in flags if isinstance(f, dict)]
+                if 'namespace' not in flag_names:
+                    errors.append(f"{rel(bp)}: helm release flags must include namespace")
+                if 'create-namespace' not in flag_names:
+                    errors.append(f"{rel(bp)}: helm release flags must include create-namespace")
+                if 'version' not in flag_names:
+                    errors.append(f"{rel(bp)}: helm release flags must include version")
+
+        if not has_binary:
+            errors.append(f"{rel(bp)}: missing dell.nodes.helm.Binary node")
+        if not has_repo:
+            errors.append(f"{rel(bp)}: missing dell.nodes.helm.Repo node")
+        if not has_release:
+            errors.append(f"{rel(bp)}: missing dell.nodes.helm.Release node")
+
+    labels = data.get('labels', {})
+    blueprint_labels = data.get('blueprint_labels', {})
+    if 'csys-obj-type' not in labels:
+        errors.append(f"{rel(bp)}: labels must include csys-obj-type")
+    if 'obj-type' not in blueprint_labels or 'csys-obj-type' not in blueprint_labels:
+        errors.append(f"{rel(bp)}: blueprint_labels must include obj-type and csys-obj-type")
+
+for ch in changelogs:
+    data = load_yaml(ch)
+    if not isinstance(data, dict):
+        continue
+
+    expect(data.get('tosca_definitions_version') == 'dell_1_1',
+           f"{rel(ch)}: tosca_definitions_version must be dell_1_1")
+
+    imports = data.get('imports')
+    expect(isinstance(imports, list), f"{rel(ch)}: imports must be a list")
+    if isinstance(imports, list):
+        expect('dell/types/types.yaml' in imports,
+               f"{rel(ch)}: imports must include dell/types/types.yaml")
+
+    changelog = data.get('dsl_definitions', {}).get('changelog', {})
+    if not isinstance(changelog, dict) or not changelog:
+        errors.append(f"{rel(ch)}: dsl_definitions.changelog must be a non-empty map")
+    else:
+        for version, entries in changelog.items():
+            if not semver_re.match(str(version)):
+                errors.append(f"{rel(ch)}: changelog version '{version}' is not semver")
+            if not isinstance(entries, list) or not entries:
+                errors.append(f"{rel(ch)}: changelog {version} must be a non-empty list")
+                continue
+            for idx, item in enumerate(entries):
+                if not isinstance(item, dict):
+                    errors.append(f"{rel(ch)}: changelog {version}[{idx}] must be a map")
+                    continue
+                for key in ('ticket', 'developer', 'description'):
+                    if key not in item:
+                        errors.append(f"{rel(ch)}: changelog {version}[{idx}] missing '{key}'")
+
+if errors:
+    print('Validation FAILED')
+    for e in errors:
+        print(f'- {e}')
+    if warnings:
+        print('Warnings:')
+        for w in warnings:
+            print(f'- {w}')
+    sys.exit(1)
+
+print('Validation PASSED')
+if warnings:
+    print('Warnings:')
+    for w in warnings:
+        print(f'- {w}')
+PY

--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ Template to deploy/manage JFrog Artifactory enterprise cluster on various cloud 
 
 * [Ansible](Ansible/ansible_collections/jfrog/platform/README.md)
 * [Openshift 4](Openshift4/README.md)
+* [JFrog-dell-blueprints](JFrog-dell-blueprints/README.md)
 


### PR DESCRIPTION
#### PR Checklist
- [x] Title of the PR starts with installer/product name (e.g. `[dell-blueprints]`)
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:

Adds JFrog Dell blueprints for TOSCA-based deployment of the JFrog Platform on Dell infrastructure, and moves GitHub-specific files to the correct location.

## Summary

- **Add `jfrog-dell-blueprints/`** — TOSCA blueprints for deploying JFrog Platform (Artifactory, Xray, etc.) on Dell infrastructure with configurable sizing templates, networking modes, and Helm chart integration.
- **Move `.github/` to repo root** — The `jfrog-dell-blueprints/.github/` directory (workflows, CODE_OF_CONDUCT) was nested inside the subdirectory where GitHub cannot discover it. Moved contents to the repository root `.github/` so workflows actually run and community files are displayed.
- **Workflow adjustments:**
  - Renamed workflow files with `dell-` prefix (`dell-release.yaml`, `dell-validate-blueprints.yaml`) to avoid collisions with existing workflows.
  - Added `working-directory: jfrog-dell-blueprints` to build/validation steps.
  - Scoped `paths:` triggers to `jfrog-dell-blueprints/` so they only fire on relevant changes.

### Files added
| Path | Description |
|------|-------------|
| `jfrog-dell-blueprints/blueprints/` | TOSCA blueprint YAML definitions for JFrog Platform |
| `jfrog-dell-blueprints/scripts/` | Build, validation, and sync helper scripts |
| `jfrog-dell-blueprints/Makefile` | Build orchestration for release artifacts |
| `.github/workflows/dell-release.yaml` | CI workflow for tagged releases |
| `.github/workflows/dell-validate-blueprints.yaml` | CI workflow for PR blueprint validation |
| `.github/CODE_OF_CONDUCT.md` | Contributor Code of Conduct |

**Which issue this PR fixes**: fixes INST-20783

**Special notes for your reviewer**:

The `.github/` directory was previously inside `jfrog-dell-blueprints/` where GitHub ignores it entirely. Workflows would never have triggered and the CODE_OF_CONDUCT would not have been displayed. This PR corrects that by placing everything under the repo root `.github/`.


Made with [Cursor](https://cursor.com)