### PR TITLE
[dell-blueprints] Fix broken pipe in Makefile chart version resolution

### DIFF
--- a/JFrog-dell-blueprints/Makefile
+++ b/JFrog-dell-blueprints/Makefile
@@ -34,7 +34,7 @@ resolve_chart_version:
 ifneq ($(strip $(CHART_VERSION)),)
 	$(eval RESOLVED_CHART_VERSION := $(CHART_VERSION))
 else
-	$(eval RESOLVED_CHART_VERSION := $(shell ./scripts/get_latest_jfrog_platform_version.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1))
+	$(eval RESOLVED_CHART_VERSION := $(shell ./scripts/get_latest_jfrog_platform_version.sh | grep -oEm1 '[0-9]+\.[0-9]+\.[0-9]+'))
 endif
 	@if [ -z "$(RESOLVED_CHART_VERSION)" ]; then \
 		echo "Error: Unable to resolve Helm chart version." >&2; \


### PR DESCRIPTION
Replace `grep -oE | head -1` with `grep -oEm1` in the resolve_chart_version target. The piped `head -1` causes a SIGPIPE when grep tries to write additional matches after head exits, failing the build with "grep: write error: Broken pipe".

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

