### PR TITLE
[dell-blueprints] Fix SIGPIPE in Makefile chart version resolution

### DIFF
--- a/JFrog-dell-blueprints/Makefile
+++ b/JFrog-dell-blueprints/Makefile
@@ -34,7 +34,7 @@ resolve_chart_version:
 ifneq ($(strip $(CHART_VERSION)),)
 	$(eval RESOLVED_CHART_VERSION := $(CHART_VERSION))
 else
-	$(eval RESOLVED_CHART_VERSION := $(shell ./scripts/get_latest_jfrog_platform_version.sh | grep -oEm1 '[0-9]+\.[0-9]+\.[0-9]+'))
+	$(eval RESOLVED_CHART_VERSION := $(shell v=$$(./scripts/get_latest_jfrog_platform_version.sh 2>/dev/null); echo "$$v" | grep -oEm1 '[0-9]+\.[0-9]+\.[0-9]+'))
 endif
 	@if [ -z "$(RESOLVED_CHART_VERSION)" ]; then \
 		echo "Error: Unable to resolve Helm chart version." >&2; \


### PR DESCRIPTION
The script uses `set -euo pipefail` and outputs multi-line text. Piping directly to `grep -m1` causes the script to receive SIGPIPE when grep exits after finding its match, killing the script before it finishes writing.

Fix: capture script output into a shell variable first, then grep the variable. This avoids piping from the script entirely.

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

