### PR TITLE
[dell-blueprints] Fix SIGPIPE in get_latest_jfrog_platform_version.sh

### DIFF
--- a/JFrog-dell-blueprints/scripts/get_latest_jfrog_platform_version.sh
+++ b/JFrog-dell-blueprints/scripts/get_latest_jfrog_platform_version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Fetch the latest stable version of the JFrog Platform Helm chart.
-# Requires: curl, grep, sort, head (no Helm CLI needed).
+# Requires: curl, grep (no Helm CLI needed).
 
 set -euo pipefail
 
@@ -11,10 +11,10 @@ REPO_INDEX_URL="https://charts.jfrog.io/index.yaml"
 # the target chart to extract the version without needing yq or Helm CLI.
 get_latest_chart_version() {
   local chart_name="$1"
-  curl -sL "$REPO_INDEX_URL" 2>/dev/null \
-    | grep -oE "${chart_name}-[0-9]+\.[0-9]+\.[0-9]+\.tgz" \
-    | head -1 \
-    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
+  local index tgz_match
+  index=$(curl -sL "$REPO_INDEX_URL" 2>/dev/null) || return 1
+  tgz_match=$(grep -oEm1 "${chart_name}-[0-9]+\.[0-9]+\.[0-9]+\.tgz" <<< "$index") || return 1
+  grep -oE '[0-9]+\.[0-9]+\.[0-9]+' <<< "$tgz_match"
 }
 
 CHARTS=(


### PR DESCRIPTION
Replace grep|head-1 pipeline with here-strings to avoid SIGPIPE under set -euo pipefail. The pipe caused grep to receive SIGPIPE (exit 141) when head exited, failing the script on Ubuntu/GNU grep in CI and producing empty chart version output.

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

