### PR TITLE
[ansible/platform] Make service user shells configurable

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
+++ b/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this collection will be documented in this file.
 ## [11.5.3] - May 19, 2026
 * Update dependency artifactory version to 7.146.12
 * Update dependency xray version to 3.143.16
+* Add configurable service user shell variables for Artifactory, Xray, and Distribution roles.
 
 ## [11.5.2] - May 13, 2026
 * Update dependency artifactory version to 7.146.10

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/README.md
@@ -4,6 +4,7 @@ The artifactory role installs the Artifactory Pro software onto the host. Per th
 ## Role Variables
 * _server_name_: **mandatory** This is the server name. eg. "artifactory.54.175.51.178.xip.io"
 * _artifactory_upgrade_only_: Perform an software upgrade only. Default is false.
+* _artifactory_user_shell_: Shell assigned to the Artifactory service user. Default is `/bin/bash`.
 
 Additional variables can be found in [defaults/main.yml](./defaults/main.yml).
 

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/defaults/main.yml
@@ -42,6 +42,7 @@ postgres_driver_version: 42.6.0
 postgres_driver_download_url: "https://repo1.maven.org/maven2/org/postgresql/postgresql/{{ postgres_driver_version }}/postgresql-{{ postgres_driver_version }}.jar"
 artifactory_user: artifactory
 artifactory_group: artifactory
+artifactory_user_shell: /bin/bash
 artifactory_daemon: artifactory
 artifactory_uid: 1030
 artifactory_gid: 1030

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory/tasks/install.yml
@@ -30,7 +30,7 @@
     group: "{{ artifactory_group }}"
     create_home: true
     home: "{{ artifactory_home }}"
-    shell: /bin/bash
+    shell: "{{ artifactory_user_shell }}"
     state: present
 
 - name: Allow using crontab

--- a/Ansible/ansible_collections/jfrog/platform/roles/distribution/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/roles/distribution/README.md
@@ -3,6 +3,7 @@ The Distribution role will install distribution software onto the host. An Artif
 
 ### Role Variables
 * _distribution_upgrade_only_: Perform an software upgrade only. Default is false.
+* _distribution_user_shell_: Shell assigned to the Distribution service user. Default is `/bin/bash`.
 
 Additional variables can be found in [defaults/main.yml](./defaults/main.yml).
 ## Example Playbook

--- a/Ansible/ansible_collections/jfrog/platform/roles/distribution/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/distribution/defaults/main.yml
@@ -30,6 +30,7 @@ distribution_service_file: /lib/systemd/system/distribution.service
 # distribution users and groups
 distribution_user: distribution
 distribution_group: distribution
+distribution_user_shell: /bin/bash
 
 distribution_uid: 1040
 distribution_gid: 1040

--- a/Ansible/ansible_collections/jfrog/platform/roles/distribution/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/distribution/tasks/install.yml
@@ -14,7 +14,7 @@
     group: "{{ distribution_group }}"
     create_home: true
     home: "{{ distribution_home }}"
-    shell: /bin/bash
+    shell: "{{ distribution_user_shell }}"
     state: present
 
 - name: Allow using crontab

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/README.md
@@ -3,6 +3,7 @@ The xray role will install Xray software onto the host. An Artifactory server an
 
 ### Role Variables
 * _xray_upgrade_only_: Perform an software upgrade only. Default is false.
+* _xray_user_shell_: Shell assigned to the Xray service user. Default is `/bin/bash`.
 
 Additional variables can be found in [defaults/main.yml](./defaults/main.yml).
 ## Example Playbook

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/defaults/main.yml
@@ -22,6 +22,7 @@ xray_service_file: /lib/systemd/system/xray.service
 # Xray users and groups
 xray_user: xray
 xray_group: xray
+xray_user_shell: /bin/bash
 xray_uid: 1035
 xray_gid: 1035
 xray_daemon: xray

--- a/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/install.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/xray/tasks/install.yml
@@ -14,7 +14,7 @@
     group: "{{ xray_group }}"
     create_home: true
     home: "{{ xray_home }}"
-    shell: /bin/bash
+    shell: "{{ xray_user_shell }}"
     state: present
 
 - name: Allow using crontab


### PR DESCRIPTION
#### PR Checklist
- [x] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [x] CHANGELOG.md updated
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:

Adds service-user shell variables for the Ansible Platform roles:

- `artifactory_user_shell`
- `xray_user_shell`
- `distribution_user_shell`

The defaults remain `/bin/bash`, so existing behavior is unchanged. Operators who need non-interactive service accounts can now set the relevant variable to `/sbin/nologin`, `/usr/sbin/nologin`, or another site-approved shell without patching the role tasks.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #488

**Verification**:

- `git diff --check`
- Parsed touched defaults/task YAML files with PyYAML.
- `rg "user_shell|service user shell|shell:" -n Ansible\ansible_collections\jfrog\platform\roles\artifactory Ansible\ansible_collections\jfrog\platform\roles\xray Ansible\ansible_collections\jfrog\platform\roles\distribution Ansible\ansible_collections\jfrog\platform\CHANGELOG.md`

Not run:

- `ansible` / `ansible-lint`, because they are not installed in this Windows workspace.

**Special notes for your reviewer**:

I kept the default shell unchanged to avoid a behavior change for existing installations; this only exposes the hardening knob.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed.
