### PR TITLE
ansible: expose nginx proxy temp file size

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
+++ b/Ansible/ansible_collections/jfrog/platform/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this collection will be documented in this file.
 ## [11.5.3] - May 19, 2026
 * Update dependency artifactory version to 7.146.12
 * Update dependency xray version to 3.143.16
+* Artifactory NGINX - Added `artifactory_nginx_proxy_max_temp_file_size` to configure `proxy_max_temp_file_size` [GH-445](https://github.com/jfrog/JFrog-Cloud-Installers/issues/445)
 
 ## [11.5.2] - May 13, 2026
 * Update dependency artifactory version to 7.146.10

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/README.md
@@ -23,6 +23,7 @@ The artifactory_nginx role installs and Optionally configures nginx for SSL.
 * _nginx_worker_processes_: The worker_processes configuration for nginx. Defaults to 1.
 * _artifactory_docker_registry_subdomain_: Whether to add a redirect directive to the nginx config for the use of docker
   subdomains.
+* _artifactory_nginx_proxy_max_temp_file_size_: Sets the NGINX `proxy_max_temp_file_size` directive in the Artifactory reverse proxy. Defaults to `1024m`; set to `0` to disable the limit.
 
 * _mtls_ca_certificate_install_: `false` - Enable mTLS by updating to `true`
 * _mtls_mtls_ca_certificate_crt_name_: This is the filename of the CA certificate for mTLS

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/defaults/main.yml
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/defaults/main.yml
@@ -28,6 +28,7 @@ redirect_http_to_https_enabled: true
 
 nginx_worker_processes: 1
 artifactory_docker_registry_subdomain: false
+artifactory_nginx_proxy_max_temp_file_size: 1024m
 
 artifactory_conf_template: artifactory.conf.j2
 nginx_conf_template: nginx.conf.j2

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/templates/artifactory.conf.j2
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/templates/artifactory.conf.j2
@@ -47,6 +47,7 @@
   {% if artifactory_docker_registry_subdomain %}rewrite ^/(v1|v2)/(.*) /artifactory/api/docker/$repo/$1/$2;{% endif %}
   chunked_transfer_encoding on;
   client_max_body_size 0;
+  proxy_max_temp_file_size {{ artifactory_nginx_proxy_max_temp_file_size }};
   location / {
   proxy_read_timeout  2400s;
   proxy_pass_header   Server;


### PR DESCRIPTION
## Summary
- add `artifactory_nginx_proxy_max_temp_file_size` for the Artifactory NGINX role
- keep the default at `1024m`, matching NGINX's existing implicit default
- render the directive in `artifactory.conf` so users can set `0` for large artifact downloads
- update the role README and collection changelog

## Verification
- `git diff --check`
- parsed `roles/artifactory_nginx/defaults/main.yml` with PyYAML
- `rg "artifactory_nginx_proxy_max_temp_file_size|proxy_max_temp_file_size" Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx Ansible/ansible_collections/jfrog/platform/CHANGELOG.md`

Not run: `ansible` / `ansible-lint`, because Ansible is not installed in this Windows workspace.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed.

Fixes #445