### PR TITLE
[dell-blueprints] Fix release.sh to run from any directory

### DIFF
--- a/JFrog-Dell-Blueprints/scripts/release.sh
+++ b/JFrog-Dell-Blueprints/scripts/release.sh
@@ -4,6 +4,13 @@
 
 set -euo pipefail
 
+# ── Run from the blueprint root ──────────────────────────────────────
+# This script lives in <blueprint-root>/scripts. Resolve its own
+# location and cd to the parent so all relative paths (e.g. the
+# "blueprints" directory) work regardless of the caller's cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
 # ── Non-interactive mode ─────────────────────────────────────────────
 ASSUME_YES=${ASSUME_YES:-0}
 if [[ "${1:-}" == "-y" ]]; then


### PR DESCRIPTION
## Summary
- `release.sh` checked for a relative `blueprints` directory, so invoking it from inside `scripts/` failed with `Error: Blueprint directory 'blueprints' not found.`
- The script now resolves its own location and `cd`s to the blueprint root before doing any path-relative work, so it runs correctly regardless of the caller's working directory.

## Test plan
- [ ] `cd JFrog-Dell-Blueprints/scripts && ./release.sh` proceeds past the blueprint-directory check (previously errored).
- [ ] Running from the blueprint root (`JFrog-Dell-Blueprints/`) still works.
- [ ] `bash -n scripts/release.sh` reports no syntax errors.

Made with [Cursor](https://cursor.com)