### PR TITLE
[dell-blueprints] Fix Makefile REVISION bad substitution

### DIFF
--- a/JFrog-Dell-Blueprints/Makefile
+++ b/JFrog-Dell-Blueprints/Makefile
@@ -10,7 +10,7 @@ ZIP_OUTPUT_DIR        := target
 # VERSION is "local" or non-semver we fall back to 0.0.0.0 so the
 # manifest validator does not reject the build.
 REVISION              := $(shell \
-    v="$(VERSION)"; v="$${v\#v}"; \
+    v="$(VERSION)"; v=$$(printf '%s' "$$v" | sed 's/^v//'); \
     if [[ "$$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$$ ]]; then echo "$$v.0"; \
     elif [[ "$$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$$ ]]; then echo "$$v"; \
     else echo "0.0.0.0"; fi)


### PR DESCRIPTION
## Summary
- The `REVISION` make variable stripped a leading `v` from `VERSION` using bash `${v#v}`, escaped as `\#` (since `#` starts a Make comment). On the CI runner the backslash leaked into bash → `${v\#v}: bad substitution`, so `$(shell ...)` returned empty.
- An empty `REVISION` then failed the manifest step: `--revision must be 4-part MAJOR.MINOR.PATCH.BUILD; got ''` (`make all` exited 2).
- Replaced the `#`-based expansion with a `sed` strip (no `#` character), so the leading `v` is removed safely.

## Behaviour after fix
| `VERSION` | `REVISION` |
|---|---|
| `1.0.0` | `1.0.0.0` |
| `v1.0.0` | `1.0.0.0` |
| `1.2.3.4` | `1.2.3.4` |
| `local` / empty | `0.0.0.0` |

## Test plan
- [ ] Tag `jfrog-dell-blueprints/v1.0.0` → `make all VERSION=1.0.0` builds the bundle and writes `manifest.yaml` with revision `1.0.0.0` (no `bad substitution`, no manifest error).
- [ ] `make all` with no `VERSION` falls back to `REVISION=0.0.0.0`.

Made with [Cursor](https://cursor.com)