### PR TITLE
docs: fix typos and brand casing across documentation

### DIFF
--- a/Ansible/ansible_collections/jfrog/platform/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/README.md
@@ -110,11 +110,11 @@ All JFrog product roles support software updates. To use a role to perform a sof
 ```
 
 ## Using External Database
-If an external database for one or more products is to be used, you don't need to run `postgres` role as part of platform.yml.This can also be done by setting  `postgres_enabled` should be set to `false` in `group_vars/all/vars.yml`
+If an external database for one or more products is to be used, you don't need to run `postgres` role as part of platform.yml. This can also be done by setting  `postgres_enabled` should be set to `false` in `group_vars/all/vars.yml`
 
 Create an external database as documented [here](https://www.jfrog.com/confluence/display/JFROG/PostgreSQL#PostgreSQL-CreatingtheArtifactoryPostgreSQLDatabase) and change corresponding product values in `group_vars/all/vars.yml`
 
-For example, for artifactory, these below values needs to be set for using external postgresql
+For example, for artifactory, these below values need to be set for using external postgresql
 
 ```yaml
 postgres_enabled: false
@@ -123,7 +123,7 @@ artifactory_db_type: postgresql
 artifactory_db_driver: org.postgresql.Driver
 artifactory_db_name: <external_db_name>
 artifactory_db_user: <external_db_user>
-artifactory_db_password: <external_db_pasword>
+artifactory_db_password: <external_db_password>
 artifactory_db_url: jdbc:postgresql://<external_db_host_ip>:5432/{{ artifactory_db_name }}
 
 ```

--- a/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/README.md
+++ b/Ansible/ansible_collections/jfrog/platform/roles/artifactory_nginx/README.md
@@ -82,7 +82,7 @@ mtls_ca_certificate_crt: |
 mtls_ca_certificate_key: |
 
 
-## Step: 2 - Arifactory Changes
+## Step: 2 - Artifactory Changes
 
 ### Enable mTLS Configuration
 Under `artifactory_access_config_patch`, add the configuration in the following location to enable mTLS:

--- a/Openshift4/README.md
+++ b/Openshift4/README.md
@@ -1,51 +1,51 @@
-# JFrog Platform On Openshift 
+# JFrog Platform On OpenShift 
 
 ## Announcement (August 2024)  
-JFrog Platform on Openshift official support was added to the [JFrog Helm Charts](https://github.com/jfrog/charts/tree/master). 
+JFrog Platform on OpenShift official support was added to the [JFrog Helm Charts](https://github.com/jfrog/charts/tree/master). 
 
-JFrog highly recommends using Helm Charts for deployments on Openshift clusters.
+JFrog highly recommends using Helm Charts for deployments on OpenShift clusters.
 
 For more information, see [Install Artifactory HA](https://jfrog.com/help/r/jfrog-installation-setup-documentation/install-artifactory-ha-on-openshift) and [Install Xray HA](https://jfrog.com/help/r/jfrog-installation-setup-documentation/xray-ha-openshift-installation).
 
-## JFrog Openshift Operators
-The JFrog Openshift Operators are maintained as alternative method of deploying JFrog products for OpenShift platforms.
+## JFrog OpenShift Operators
+The JFrog OpenShift Operators are maintained as alternative method of deploying JFrog products for OpenShift platforms.
 
 ### Repo Layout
 
 | Folder                          | Purpose                                                 |
 |---------------------------------|---------------------------------------------------------|
-| helm                            | Contains the Openshift Helm charts used by the Operator |
-| helm/openshift-artifactory-ha   | Openshift Artifactory HA helm chart                     |
-| helm/openshift-xray             | Openshift Xray helm chart                               |
-| helm/openshift-pipelines        | Opneshift Pipelines helm chart                          | 
-| operator                        | Contains the Openshift certified operators code base    |
+| helm                            | Contains the OpenShift Helm charts used by the Operator |
+| helm/openshift-artifactory-ha   | OpenShift Artifactory HA helm chart                     |
+| helm/openshift-xray             | OpenShift Xray helm chart                               |
+| helm/openshift-pipelines        | OpenShift Pipelines helm chart                          | 
+| operator                        | Contains the OpenShift certified operators code base    |
 | operator/artifactory-ha-operator| Artifactory Enterprise Operator                         |
 | operator/xray-operator          | Xray Enterprise Operator                                |
 | operator/pipeline-operator      | Pipelines Operator (Beta)                               |
 
 ### How to install?
 
-You can find the Redhat certified Operators in the Operatorhub in your Openshift web console.
+You can find the Redhat certified Operators in the Operatorhub in your OpenShift web console.
 
-You will need to be an administrator of your Openshift cluster to install our operator.
+You will need to be an administrator of your OpenShift cluster to install our operator.
 
 ### Security Context Constraints
 
-The `restricted` security context constraint will prevent the helm or operator from deploying into Openshift on most namespaces.
+The `restricted` security context constraint will prevent the helm or operator from deploying into OpenShift on most namespaces.
 
-To enable either the helm chart or operator to deploy into your Openshift cluster access to the `anyuid` security context constraint will need to be apply to the relevant service account in the associated namespace.
+To enable either the helm chart or operator to deploy into your OpenShift cluster access to the `anyuid` security context constraint will need to be apply to the relevant service account in the associated namespace.
 
 Below is an example of applying the `anyuid` scc to the service account `openshiftartifactoryha-artifactory-ha` in the namespace `artifactory`:
 
 `oc adm policy add-scc-to-user anyuid -z openshiftartifactoryha-artifactory-ha -n artifactory`
 
-Once the `anyuid` scc has been applied to the correct service accounts the helm charts or operators will deploy into your Openshift cluster.
+Once the `anyuid` scc has been applied to the correct service accounts the helm charts or operators will deploy into your OpenShift cluster.
 
 ### Custom User or Group Ids
 
 The images uploaded to `registry.redhat.connect.com` that the helm charts and operators use have been modified from the standard docker images available at `docker.bintray.io`
 
-These images have been customized to run in the Openshift user id and group id range of `1000720000/10000`
+These images have been customized to run in the OpenShift user id and group id range of `1000720000/10000`
 
 If you need to use another custom user id and/or group id range you can change the `uid` and `gid` values in `values.yaml` of the relevant helm chart or operator yaml deployment.
 
@@ -70,18 +70,18 @@ Some environments do not allow root. In these scenarios users can remove the `cu
             name: volume
 ````
 
-Once this has been removed there is no other root user permissions are required to deploy into Openshift.
+Once this has been removed there is no other root user permissions are required to deploy into OpenShift.
 
 ### Why are there different helm charts?
 
-The charts in the helm folder are used specifically to create the helm based operator for the certification process to enable it into the Openshift Operatorhub as a certified operator.
+The charts in the helm folder are used specifically to create the helm based operator for the certification process to enable it into the OpenShift Operatorhub as a certified operator.
 
-The `values.yaml` contained in those relevant charts have been modified to work in Redhat Openshift. The base chart however has not been changed only made a sub-chart.
+The `values.yaml` contained in those relevant charts have been modified to work in Redhat OpenShift. The base chart however has not been changed only made a sub-chart.
 
-Helm users can reference the `values.yaml` to modify their own deployments to work with Openshift.
+Helm users can reference the `values.yaml` to modify their own deployments to work with OpenShift.
 
 ### Contributing
-Please read [CONTRIBUTING.md](JFrog-Cloud-Installers/Openshift4/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read [CONTRIBUTING.md](JFrog-Cloud-Installers/OpenShift4/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
 
 ### Versioning
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/jfrog/JFrog-Cloud-Installers/tags).

--- a/Openshift4/helm/openshift-pipelines/charts/pipelines/README.md
+++ b/Openshift4/helm/openshift-pipelines/charts/pipelines/README.md
@@ -23,7 +23,7 @@ This chart will do the following:
   - Default StorageClass set to allow services using the default StorageClass for persistent storage
 - A running Artifactory 7.7.x with Enterprise+ License
   - Precreated repository `jfrogpipelines` in Artifactory type `Generic` with layout `maven-2-default`
-- [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed and setup to use the cluster
+- [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed and set up to use the cluster
 - [Helm](https://helm.sh/) v2 or v3 installed
 
 
@@ -40,7 +40,7 @@ helm repo update
 
 ### Artifactory Connection Details
 
-In order to connect Pipelines to your Artifactory installation, you have to use a Join Key, hence it is *MANDATORY* to provide a Join Key and Jfrog Url to your Pipelines installation. Here's how you do that:
+In order to connect Pipelines to your Artifactory installation, you have to use a Join Key, hence it is *MANDATORY* to provide a Join Key and JFrog URL to your Pipelines installation. Here's how you do that:
 
 Retrieve the connection details of your Artifactory installation, from the UI - https://www.jfrog.com/confluence/display/JFROG/General+Security+Settings#GeneralSecuritySettings-ViewingtheJoinKey.
 
@@ -51,9 +51,9 @@ Retrieve the connection details of your Artifactory installation, from the UI - 
 Before deploying Pipelines you need to have the following
 - A running Kubernetes cluster
 - An [Artifactory ](https://hub.helm.sh/charts/jfrog/artifactory) or [Artifactory HA](https://hub.helm.sh/charts/jfrog/artifactory-ha) with Enterprise+ License
-  - Precreated repository `jfrogpipelines` in Artifactiry type `Generic` with layout `maven-2-default`
+  - Precreated repository `jfrogpipelines` in Artifactory type `Generic` with layout `maven-2-default`
 - Deployed [Nginx-ingress controller](https://hub.helm.sh/charts/stable/nginx-ingress)
-- [Optional] Deployed [Cert-manager](https://hub.helm.sh/charts/jetstack/cert-manager) for automatic management of TLS certificates with [Lets Encrypt](https://letsencrypt.org/)
+- [Optional] Deployed [Cert-manager](https://hub.helm.sh/charts/jetstack/cert-manager) for automatic management of TLS certificates with [Let's Encrypt](https://letsencrypt.org/)
 - [Optional] TLS secret needed for https access
 
 #### Prepare configurations
@@ -158,7 +158,7 @@ helm upgrade --install pipelines --namespace pipelines center/jfrog/pipelines -f
 ```
 
 ### Using Vault in Production environments
-To use vault securely you must set the disablemlock setting in the values.yaml to false as per the Hashicorp Vault recommendations here:
+To use vault securely you must set the disablemlock setting in the values.yaml to false as per the HashiCorp Vault recommendations here:
 
 https://www.vaultproject.io/docs/configuration#disable_mlock
 
@@ -199,7 +199,7 @@ helm status pipelines --namespace pipelines
 ```
 
 ### Pipelines Version
-- By default, the pipelines images will use the value `appVersion` in the Chart.yml. This can be over-ridden by adding `version` to the pipelines section of the values.yml
+- By default, the pipelines images will use the value `appVersion` in the Chart.yml. This can be overridden by adding `version` to the pipelines section of the values.yml
 
 ### Build Plane
 

--- a/Openshift4/operator/artifactory-ha-operator/README.md
+++ b/Openshift4/operator/artifactory-ha-operator/README.md
@@ -1,8 +1,8 @@
 # JFrog Artifactory Enterprise Operator
 
-This code base is intended to deploy Artifactory HA as an operator to an Openshift4 cluster. You can run the operator either through the operator-sdk, operator.yaml, or the Operatorhub.
+This code base is intended to deploy Artifactory HA as an operator to an OpenShift4 cluster. You can run the operator either through the operator-sdk, operator.yaml, or the Operatorhub.
 
-Openshift OperatorHub has the latest official supported Cluster Service Version (CSV) for the OLM catalog.
+OpenShift OperatorHub has the latest official supported Cluster Service Version (CSV) for the OLM catalog.
 
 
 ## Security Context Constraints
@@ -19,15 +19,15 @@ These instructions will get you a copy of the project up and running on your loc
 
 ## Prerequisites
 
-###### Openshift 4 Cluster
+###### OpenShift 4 Cluster
 
 Available on AWS, GCP, or Azure. Follow the Cloud installer guide available here:
 
-[Openshift 4 Installers](https://cloud.redhat.com/openshift/install)
+[OpenShift 4 Installers](https://cloud.redhat.com/openshift/install)
 
 Or run it locally using CodeReadyContainers.
 
-[Code Ready Container Installer](https://cloud.redhat.com/openshift/install/crc/installer-provisioned)
+[Code Ready Containers Installer](https://cloud.redhat.com/openshift/install/crc/installer-provisioned)
 
 Note if you are going to use CodeReadyContainers to test this Operator you will need to ensure:
 
@@ -35,16 +35,16 @@ Note if you are going to use CodeReadyContainers to test this Operator you will 
  - create at least one Persistent volume of 200Gi per Artifactory node used in HA configuration
 ```
 
-###### Openshift 4 Command Line Tools
+###### OpenShift 4 Command Line Tools
 
-Download and install the Openshift command line tool: oc
+Download and install the OpenShift command line tool: oc
 
 [Getting Started with CLI](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html)
 
 ## Cluster Setup
 ###### Security Context Constraints - Anyuid
 
-Openshift only allows statefulsets / pods to run in specific user and group id ranges.
+OpenShift only allows statefulsets / pods to run in specific user and group id ranges.
 Artifactory currently uses users outside of this allowed range.
 For this reason the service account for the operator in the jfrog-artifactory namespace must be granted anyuid privileges.
 
@@ -70,13 +70,13 @@ oc patch scc privileged --patch  '{"users":["system:admin","system:serviceaccoun
 
 Artifactory HA nodes by default request persistent volume claims 200 Gbs in size. 
 
-If your cluster does not already have existing persistent volumes that are 200Gi you will need to create new persistent volumes that are large enough to bound the claims to.
+If your cluster does not already have existing persistent volumes that are 200Gi you will need to create new persistent volumes that are large enough to bind the claims to.
 
 ## Installation types
 ###### OLM Catalog
-To install via the OLM catalog download the operator from the Operator hub and install it via the Openshift console GUI
+To install via the OLM catalog download the operator from the Operator hub and install it via the OpenShift console GUI
 
-To test OLM catalog installs you will need to deploy the lastest ClusterServiceVersion found at:
+To test OLM catalog installs you will need to deploy the latest ClusterServiceVersion found at:
 
 ```
 deploy/olm-catalog/artifactory-ha-operator/X.X.X/artifactory-ha-operator.vX.X.X.clusterserviceversion.yaml
@@ -99,11 +99,11 @@ This will deploy the operator into the cluster.
 
 ## Local Testing
 
-Please refer to cluster setup. Ensure all steps have been completed prior to local testing against code ready containers.
+Please refer to cluster setup. Ensure all steps have been completed prior to local testing against Code Ready Containers.
 
 Follow these steps:
 
-Install code ready containers if you do not already have it installed.
+Install Code Ready Containers if you do not already have it installed.
 
 Run your cluster with 2 cpus and 8192 MBs of memory at a minimum to support HA:
 
@@ -120,7 +120,7 @@ crc start -c 4 -m 16384
 Create file: 
 
 ```
-JFrog-Cloud-Installers/Openshift4/artifactory.cluster.license
+JFrog-Cloud-Installers/OpenShift4/artifactory.cluster.license
 ```
 
 Paste your license keys into this file for HA configuration of multiple nodes.
@@ -130,7 +130,7 @@ Paste your license keys into this file for HA configuration of multiple nodes.
 Run: 
 
 ```
-JFrog-Cloud-Installers/Openshift4/artifactory-ha-operator/setup.sh
+JFrog-Cloud-Installers/OpenShift4/artifactory-ha-operator/setup.sh
 ```
 
 ###### Operator-sdk local
@@ -138,12 +138,12 @@ JFrog-Cloud-Installers/Openshift4/artifactory-ha-operator/setup.sh
 Run: 
 
 ```
-cd JFrog-Cloud-Installers/Openshift4/artifactory-ha-operator
+cd JFrog-Cloud-Installers/OpenShift4/artifactory-ha-operator
 operator-sdk up local
 ```
 
 ## Contributing
-Please read [CONTRIBUTING.md](JFrog-Cloud-Installers/Openshift4/artifactory-ha-operator/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read [CONTRIBUTING.md](JFrog-Cloud-Installers/OpenShift4/artifactory-ha-operator/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
 
 ## Versioning
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/jfrog/JFrog-Cloud-Installers/tags).

--- a/Openshift4/operator/pipeline-operator/helm-charts/openshift-pipelines/charts/pipelines/README.md
+++ b/Openshift4/operator/pipeline-operator/helm-charts/openshift-pipelines/charts/pipelines/README.md
@@ -23,7 +23,7 @@ This chart will do the following:
   - Default StorageClass set to allow services using the default StorageClass for persistent storage
 - A running Artifactory 7.7.x with Enterprise+ License
   - Precreated repository `jfrogpipelines` in Artifactory type `Generic` with layout `maven-2-default`
-- [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed and setup to use the cluster
+- [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed and set up to use the cluster
 - [Helm](https://helm.sh/) v2 or v3 installed
 
 
@@ -40,7 +40,7 @@ helm repo update
 
 ### Artifactory Connection Details
 
-In order to connect Pipelines to your Artifactory installation, you have to use a Join Key, hence it is *MANDATORY* to provide a Join Key and Jfrog Url to your Pipelines installation. Here's how you do that:
+In order to connect Pipelines to your Artifactory installation, you have to use a Join Key, hence it is *MANDATORY* to provide a Join Key and JFrog URL to your Pipelines installation. Here's how you do that:
 
 Retrieve the connection details of your Artifactory installation, from the UI - https://www.jfrog.com/confluence/display/JFROG/General+Security+Settings#GeneralSecuritySettings-ViewingtheJoinKey.
 
@@ -51,9 +51,9 @@ Retrieve the connection details of your Artifactory installation, from the UI - 
 Before deploying Pipelines you need to have the following
 - A running Kubernetes cluster
 - An [Artifactory ](https://hub.helm.sh/charts/jfrog/artifactory) or [Artifactory HA](https://hub.helm.sh/charts/jfrog/artifactory-ha) with Enterprise+ License
-  - Precreated repository `jfrogpipelines` in Artifactiry type `Generic` with layout `maven-2-default`
+  - Precreated repository `jfrogpipelines` in Artifactory type `Generic` with layout `maven-2-default`
 - Deployed [Nginx-ingress controller](https://hub.helm.sh/charts/stable/nginx-ingress)
-- [Optional] Deployed [Cert-manager](https://hub.helm.sh/charts/jetstack/cert-manager) for automatic management of TLS certificates with [Lets Encrypt](https://letsencrypt.org/)
+- [Optional] Deployed [Cert-manager](https://hub.helm.sh/charts/jetstack/cert-manager) for automatic management of TLS certificates with [Let's Encrypt](https://letsencrypt.org/)
 - [Optional] TLS secret needed for https access
 
 #### Prepare configurations
@@ -158,7 +158,7 @@ helm upgrade --install pipelines --namespace pipelines center/jfrog/pipelines -f
 ```
 
 ### Using Vault in Production environments
-To use vault securely you must set the disablemlock setting in the values.yaml to false as per the Hashicorp Vault recommendations here:
+To use vault securely you must set the disablemlock setting in the values.yaml to false as per the HashiCorp Vault recommendations here:
 
 https://www.vaultproject.io/docs/configuration#disable_mlock
 
@@ -199,7 +199,7 @@ helm status pipelines --namespace pipelines
 ```
 
 ### Pipelines Version
-- By default, the pipelines images will use the value `appVersion` in the Chart.yml. This can be over-ridden by adding `version` to the pipelines section of the values.yml
+- By default, the pipelines images will use the value `appVersion` in the Chart.yml. This can be overridden by adding `version` to the pipelines section of the values.yml
 
 ### Build Plane
 


### PR DESCRIPTION
## Summary

Fix 33 spelling, grammar, and brand casing issues across 6 documentation files:

- **Openshift4/README.md** — Fix `Openshift` → `OpenShift` brand casing (20 instances) and `Opneshift` typo
- **Ansible/.../artifactory_nginx/README.md** — Fix `Arifactory` → `Artifactory`
- **Ansible/.../platform/README.md** — Fix `pasword` → `password`, subject-verb agreement (`needs` → `need`), missing space (`.This` → `. This`)
- **Openshift4/operator/.../pipelines/README.md** — Fix `Jfrog` → `JFrog`, `Url` → `URL`, `Artifactiry` → `Artifactory`, `setup` → `set up` (verb), `Lets Encrypt` → `Let's Encrypt`, `Hashicorp` → `HashiCorp`, `over-ridden` → `overridden`
- **Openshift4/operator/artifactory-ha-operator/README.md** — Fix `Openshift` → `OpenShift` (13 instances), `Code Ready Container` → `Code Ready Containers`, `bound` → `bind`, `lastest` → `latest`
- **Openshift4/helm/.../pipelines/README.md** — Same fixes as operator pipeline README

No functional changes — documentation only.