### PR TITLE
Auto-merge ansible update PR unless changelog has GitHub references

### DIFF
--- a/.github/workflows/ansible-update.yml
+++ b/.github/workflows/ansible-update.yml
@@ -184,15 +184,28 @@ jobs:
                             
               This is an automated update by the JFrog Ansible Collection update workflow."
 
-              gh pr create \
+              PR_URL=$(gh pr create \
                 --title "$TITLE" \
                 --body "$BODY" \
                 --base "${{ github.event.repository.default_branch }}" \
                 --head "$BRANCH" \
                 --label "automated" \
-                --label "ansible"
+                --label "ansible")
 
-              echo "Successfully created PR for Ansible Collection update"
+              echo "Successfully created PR for Ansible Collection update: $PR_URL"
+
+              # Auto-merge only when the changelog has no GitHub references
+              # (e.g. "GH-2177"). Those usually point at issues/PRs a human
+              # should review, so leave such PRs open. Only the changelog
+              # entries added by this update are inspected.
+              CHANGELOG_FILE="$COLLECTION_DIR/CHANGELOG.md"
+              if git show HEAD -- "$CHANGELOG_FILE" | grep -E '^\+' | grep -qE 'GH-[0-9]+'; then
+                echo "::notice::Changelog contains GitHub references (GH-...); leaving PR open for manual review"
+              else
+                echo "No GitHub references in changelog; auto-merging PR"
+                gh pr merge "$PR_URL" --squash --delete-branch \
+                  || echo "::warning::auto-merge failed (checks/permissions?); PR left open"
+              fi
           else
               echo "No meaningful changes detected for Ansible Collection"
               # Clean up the branch if no changes


### PR DESCRIPTION
After creating the per-update PR, auto-merge it (squash, delete branch) only when the changelog entries added by this update contain no GitHub references like "GH-2177". Such references usually point at issues/PRs a human should review, so those PRs are left open. If the merge can't complete (branch protection/permissions), the PR stays open.

#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Title of the PR starts with installer/product name (e.g. `[ansible/artifactory]`)
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md

<!--
Thank you for contributing . 

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

